### PR TITLE
Bug: generate-tx-patterns-from-pull was moved and renamed

### DIFF
--- a/src/posh/core.cljs
+++ b/src/posh/core.cljs
@@ -139,7 +139,7 @@
 
 (defn pull [conn pull-pattern entity-id]
   (pull-tx conn
-           (generate-tx-patterns-from-pull pull-pattern entity-id)
+           (pull-gen/pull-pattern-gen pull-pattern entity-id)
            pull-pattern entity-id))
 
 (defn build-query [db q args]


### PR DESCRIPTION
`generate-tx-patterns-from-pull` was moved and renamed to `pull-gen/pull-pattern-gen`

This was breaking `pull` since it hadn't been update.
