### PR TITLE
Client-server syncing (à la Web after Tomorrow / Datsync) (WIP)

### DIFF
--- a/dev/scratch.clj
+++ b/dev/scratch.clj
@@ -131,7 +131,7 @@
 
       ;; same db as :hux but without any :task/name datoms
       (pt/add-db :tasks conn (:schema @conn) {:filter 'scratch/no-task-names-filter})
-      
+
       (pt/add-pull [:db :hux] '[*] 3)
       (pt/add-filter-tx [:db :hux] '[[_ #{:category/name}]])
       (pt/add-filter-pull
@@ -161,15 +161,15 @@
 ;;(d/pull @conn '[*] [:task/name "jim"])
 
 (def conn3 (d/create-conn))
- 
+
 (d/transact!
  conn3
  [{:db/id -1
    :name "joe"}
- 
+
   {:db/id -2
    :name "sally"}
- 
+
   {:db/id -3
    :name "bob"}])
 
@@ -185,7 +185,7 @@
                   :schema (:schema @conn3)
                   :key :hux}])
 
-  
+
   )
 
 
@@ -225,7 +225,7 @@
                   :key [:db :conn2]}
                  54])
 
-;;; not working yet... 
+;;; not working yet...
   (qa/q-analyze-with-pulls {:q d/q}
                            [:pulls]
                            '[:find (pull ?tname '[*]) ?t ?uuid ?p ?level
@@ -346,7 +346,7 @@
 (comment
 
   (d/transact! conn '[[:db/add 5 :yoyo/ma "bingo"] [:db/add 8 :youou "hey"]])
-  
+
   (def poshtree (p/new-posh dcfg [:results]))
 
   (def hux (p/add-db poshtree :hux conn schema nil))
@@ -372,7 +372,7 @@
 
   (p/poshdb->conn filtp)
   (p/cache filtp)
-  
+
   (db/poshdb->db @poshtree filtp)
 
   (def f (d/filter @conn (fn [db datom] (do (println datom)
@@ -400,5 +400,17 @@
 
   )
 
+; @alexandergunnarson Sync testing
 
-
+#_(try #_(clojure.main/repl
+           :print  clojure.pprint/pprint
+           :caught clojure.pprint/pprint)
+       (require '[clojure.tools.namespace.repl :refer [refresh]])
+       (let [x (refresh)] (when (instance? Throwable x) (throw x)))
+       (set! *warn-on-reflection* true)
+       (eval `(do (reset! posh.lib.util/debug? true)
+                  (clojure.test/run-tests 'posh.lib.ratom-test)
+                  (clojure.test/run-tests 'posh.clj.datascript-test)
+                  (clojure.test/run-tests 'posh.clj.datomic-test)
+                  (clojure.test/run-tests 'posh.sync-test)))
+    (catch Throwable t (println t)))

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,11 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.228"]
-                 #_[datascript "0.15.0"]
-                 #_[com.datomic/datomic-free "0.9.5407"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
   :plugins [[lein-cljsbuild "1.1.3"]]
+  :profiles {:dev {:dependencies [[datascript "0.15.0"]
+                                  [com.datomic/datomic-free "0.9.5344"]
+                                  [org.clojure/core.async "0.2.391"]]}}
   :cljsbuild {
               :builds [ {:id "posh"
                          :source-paths ["src/"]

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
   :plugins [[lein-cljsbuild "1.1.3"]]
   :profiles {:dev {:dependencies [[datascript "0.15.0"]
                                   [com.datomic/datomic-free "0.9.5344"]
-                                  [org.clojure/core.async "0.2.391"]]}}
+                                  [org.clojure/core.async "0.2.391"]
+                                  [org.clojure/tools.namespace "0.2.11"]]}}
   :cljsbuild {
               :builds [ {:id "posh"
                          :source-paths ["src/"]

--- a/src/posh/clj/datascript.clj
+++ b/src/posh/clj/datascript.clj
@@ -1,4 +1,5 @@
 (ns posh.clj.datascript
+  "The public API of Posh's DataScript implementation for Clojure."
   (:require [posh.plugin-base :as base]
             [posh.lib.ratom :as rx]
             [posh.lib.datascript :as ldb]

--- a/src/posh/clj/datascript.clj
+++ b/src/posh/clj/datascript.clj
@@ -1,6 +1,7 @@
 (ns posh.clj.datascript
   (:require [posh.plugin-base :as base]
             [posh.lib.ratom :as rx]
+            [posh.lib.datascript :as ldb]
             [datascript.core :as d]))
 
 (def dcfg
@@ -14,7 +15,9 @@
               :listen!       d/listen!
               :conn?         d/conn?
               :ratom         rx/atom
-              :make-reaction rx/make-reaction}]
+              :make-reaction rx/make-reaction
+              :conn->schema  ldb/conn->schema
+              :additional-listeners ldb/add-schema-listener!}]
    (assoc dcfg :pull (partial base/safe-pull dcfg))))
 
 (base/add-plugin dcfg)

--- a/src/posh/clj/datomic.clj
+++ b/src/posh/clj/datomic.clj
@@ -19,6 +19,7 @@
   Lifecycle
   (start [this]
     (assert (instance? datomic.Connection datomic-conn))
+    (assert (instance? clojure.lang.IAtom listeners))
     (assert (instance? clojure.lang.IAtom interrupted?))
     (thread
       (loop []
@@ -57,7 +58,7 @@
 (defn assert-pconn [x] (assert (instance? PoshableConnection x)))
 
 (defn listen!
-  ([conn callback] (listen! conn (rand) callback))
+  ([conn callback] (listen! conn (gensym) callback))
   ([conn key callback]
      {:pre [(conn? conn)]}
      (swap! (:listeners (meta conn)) assoc key callback)

--- a/src/posh/clj/datomic.clj
+++ b/src/posh/clj/datomic.clj
@@ -24,7 +24,7 @@
       (loop []
         (when-not @interrupted?
                      ; `poll` because if `take`, still won't be nil or stop waiting when conn is released
-          (when-let [{:keys [db-after] txn-report}
+          (when-let [{:keys [db-after] :as txn-report}
                        (.poll ^java.util.concurrent.BlockingQueue
                               (d/tx-report-queue datomic-conn)
                               1

--- a/src/posh/clj/datomic.clj
+++ b/src/posh/clj/datomic.clj
@@ -1,4 +1,5 @@
 (ns posh.clj.datomic
+  "The public API of Posh's Datomic implementation (for Clojure)."
   (:require [posh.plugin-base :as base]
             [posh.lib.ratom :as rx]
             [clojure.core.async :as async

--- a/src/posh/clj/datomic.clj
+++ b/src/posh/clj/datomic.clj
@@ -15,6 +15,7 @@
               :transact!     l/transact!*
               :listen!       l/listen!
               :conn?         l/conn?
+              :conn->schema  l/conn->schema
               :->poshable-conn l/->poshable-conn
               :ratom         rx/atom
               :make-reaction rx/make-reaction}]

--- a/src/posh/clj/datomic.clj
+++ b/src/posh/clj/datomic.clj
@@ -1,138 +1,21 @@
 (ns posh.clj.datomic
   "The public API of Posh's Datomic implementation (for Clojure)."
-  (:require [posh.plugin-base :as base]
-            [posh.lib.ratom :as rx]
-            [clojure.core.async :as async
-              :refer [thread offer! <!! promise-chan]]
-            [datomic.api :as d]
-            [posh.lib.util :as u
-              :refer [debug]]))
-
-(defn datom->seq [db-after ^datomic.Datom d]
-  [(.e d) (d/ident db-after (.a d)) (.v d) (.tx d) (.added d)])
-
-; TODO import stuartsierra.component ?
-(defprotocol Lifecycle
-  (start [this])
-  (stop  [this]))
-
-(defn normalized-tx-report [{:keys [db-after] :as tx-report}]
-  (update tx-report :tx-data
-    (fn [datoms] (mapv #(datom->seq db-after %) datoms))))
-
-(defn run-listeners! [pconn tx-report']
-  (try (doseq [[_ callback] @(:listeners pconn)] (callback tx-report'))
-       (catch Throwable e (debug "WARNING:" e))))
-
-(defrecord PoshableConnection [datomic-conn listeners deduplicate-tx-idents interrupted?]
-  Lifecycle
-  (start [this]
-    (assert (instance? datomic.Connection datomic-conn))
-    (assert (instance? clojure.lang.IAtom listeners))
-    (assert (instance? clojure.lang.IAtom interrupted?))
-    ; See `transact!*` as to why the below schema+entity is required.
-    @(d/transact datomic-conn
-       [{:db/id                 (d/tempid :db.part/db)
-         :db.install/_attribute :db.part/db
-         :db/ident              :posh.clj.datomic.tx-notifier/value
-         :db/cardinality        :db.cardinality/one
-         :db/valueType          :db.type/uuid}
-        {:db/id    (d/tempid :db.part/db)
-         :db/ident ::tx-notifier}])
-    (thread
-      (loop []
-        (when-not @interrupted?
-                     ; `poll` because if `take`, still won't be nil or stop waiting when conn is released
-                     ; the poll time is how long it will take to shut down when that time comes
-          (when-let [{:keys [db-after] :as tx-report}
-                       (.poll ^java.util.concurrent.BlockingQueue
-                              (d/tx-report-queue datomic-conn)
-                              1
-                              java.util.concurrent.TimeUnit/SECONDS)]
-            (try (let [{:keys [tx-data] :as tx-report'} (normalized-tx-report tx-report)
-                       last-tx-item (last tx-data)
-                       tx-ident (when (and last-tx-item
-                                           (= (d/ident db-after (get last-tx-item 0)) ::tx-notifier)
-                                           (= (d/ident db-after (get last-tx-item 1)) :posh.clj.datomic.tx-notifier/value))
-                                  (get last-tx-item 2))]
-                   (try (debug "tx-report received in PoshableConnection")
-                        (when-not (get @deduplicate-tx-idents tx-ident)
-                          (run-listeners! this tx-report'))
-                     (finally
-                       (swap! deduplicate-tx-idents #(disj % tx-ident)))))
-              (catch Throwable e (debug "WARNING:" e)))
-            (recur)))))
-    this)
-  (stop [this]
-    (reset! interrupted? true)
-    (swap! deduplicate-tx-idents empty)
-    this))
-
-(defn ->poshable-conn [datomic-conn]
-  {:pre [(instance? datomic.Connection datomic-conn)]}
-  (let [listeners (atom nil)]
-    (with-meta (start (PoshableConnection. datomic-conn listeners (atom #{}) (atom false)))
-               {:listeners listeners})))
-
-(defn conn? [x] (instance? PoshableConnection x))
-
-(defn ->conn [x]
-  (if (conn? x)
-      (:datomic-conn x)
-      x))
-
-(defn assert-pconn [x] (assert (instance? PoshableConnection x)))
-
-(defn listen!
-  ([conn callback] (listen! conn (gensym) callback))
-  ([conn key callback]
-     {:pre [(conn? conn)]}
-     (swap! (:listeners (meta conn)) assoc key callback)
-     key))
-
-(defn db* [x]
-  (cond (instance? datomic.Database x)
-        x
-        (conn? x)
-        (-> x :datomic-conn d/db)
-        (instance? datomic.Connection x)
-        (d/db x)
-        :else x #_(throw (ex-info "Object cannot be converted into DB" {:obj x}))))
-
-(defn q* [q x & args]
-  (apply d/q q (db* x) args))
-
-(defn transact!*
-  "The main point of the additions onto Datomic's base `transact` fn is to wait for related
-   listeners to be run before returning."
-  [conn tx]
-  {:pre [(conn? conn)]}
-  (let [; In order to ensure listeners are run only once (i.e. deduplicate them),
-        ; we have to transmit to the report queue in a race-condition-free way
-        ; some sort of unique ID we know ahead of time. I'd like to just use the
-        ; txn ID, but this is not given ahead of time. Thus we must pass a squuid
-        ; to the transaction.
-        ; This is cleaner than e.g. using channels because they introduce race
-        ; conditions in this situation.
-        tx-ident   (d/squuid)
-        _          (swap! (:deduplicate-tx-idents conn) conj tx-ident)
-        tx-report  @(d/transact (->conn conn)
-                      (conj (vec tx) [:db/add ::tx-notifier :posh.clj.datomic.tx-notifier/value tx-ident]))
-        tx-report' (normalized-tx-report tx-report)
-        _          (run-listeners! conn tx-report')]
-    tx-report'))
+  (:require [posh.plugin-base   :as base]
+            [posh.lib.ratom     :as rx]
+            [datomic.api        :as d]
+            [posh.lib.datomic   :as l]))
 
 (def dcfg
-  (let [dcfg {:db            db*
+  (let [dcfg {:db            l/db*
               :pull*         d/pull
-              :q             q*
+              :q             l/q*
               :filter        d/filter
               :with          d/with
               :entid         d/entid
-              :transact!     transact!*
-              :listen!       listen!
-              :conn?         conn?
-              :->poshable-conn ->poshable-conn
+              :transact!     l/transact!*
+              :listen!       l/listen!
+              :conn?         l/conn?
+              :->poshable-conn l/->poshable-conn
               :ratom         rx/atom
               :make-reaction rx/make-reaction}]
    (assoc dcfg :pull (partial base/safe-pull dcfg))))

--- a/src/posh/clj/datomic.clj
+++ b/src/posh/clj/datomic.clj
@@ -14,7 +14,7 @@
               :entid         d/entid
               :transact!     l/transact!*
               :listen!       l/listen!
-              :conn?         l/conn?
+              :conn?         l/poshable-conn?
               :conn->schema  l/conn->schema
               :->poshable-conn l/->poshable-conn
               :ratom         rx/atom

--- a/src/posh/core.cljc
+++ b/src/posh/core.cljc
@@ -34,7 +34,6 @@
    :filters {}})
    ;; {db-id {:filter pred :as-of t :with tx-data :since t}}
 
-
 (defn add-db
   ([posh-tree db-id conn schema] (add-db posh-tree db-id conn schema nil))
   ([{:keys [dcfg conns schemas dbs cache graph] :as posh-tree}

--- a/src/posh/lib/datascript.cljc
+++ b/src/posh/lib/datascript.cljc
@@ -1,0 +1,9 @@
+(ns posh.lib.datascript)
+
+(defn conn->schema [conn] (:schema @conn))
+
+(defn add-schema-listener! [conn posh-atom db-id]
+  (add-watch conn :posh-schema-listener
+    (fn [_ _ old-state new-state]
+      (when (not= (:schema old-state) (:schema new-state))
+        (swap! posh-atom assoc-in [:schema db-id] (:schema new-state))))))

--- a/src/posh/lib/datascript.cljc
+++ b/src/posh/lib/datascript.cljc
@@ -13,3 +13,10 @@
     (fn [_ _ old-state new-state]
       (when (not= (:schema old-state) (:schema new-state))
         (swap! posh-atom assoc-in [:schema db-id] (:schema new-state))))))
+
+(defn ->schema [schema]
+  (->> schema
+       (map (fn [[k v]] [k (if (-> v :db/valueType (not= :db.type/ref))
+                               (dissoc v :db/valueType)
+                               v)]))
+       (into {})))

--- a/src/posh/lib/datascript.cljc
+++ b/src/posh/lib/datascript.cljc
@@ -1,4 +1,5 @@
-(ns posh.lib.datascript)
+(ns posh.lib.datascript
+  "General DataScript utils.")
 
 (defn conn->schema [conn] (:schema @conn))
 

--- a/src/posh/lib/datascript.cljc
+++ b/src/posh/lib/datascript.cljc
@@ -1,5 +1,10 @@
 (ns posh.lib.datascript
-  "General DataScript utils.")
+  "General DataScript utils."
+  (:require [datascript.core :as d]))
+
+(def default-partition :db.part/default)
+
+(defn tempid [] (d/tempid default-partition))
 
 (defn conn->schema [conn] (:schema @conn))
 

--- a/src/posh/lib/datomic.clj
+++ b/src/posh/lib/datomic.clj
@@ -36,10 +36,10 @@
            (finally (d/release conn))))
     (finally (d/delete-database uri))))
 
-(defn with-posh-conn [uri schemas f]
+(defn with-posh-conn [retrieve uri schemas f]
   (with-conn uri
     (fn [conn*]
-      (let [poshed (db/posh! conn*) ; This performs a `with-meta` so the result is needed
+      (let [poshed (db/posh-one! conn* retrieve) ; This performs a `with-meta` so the result is needed
             conn   (-> poshed :conns :conn0) ; Has the necessary meta ; TODO simplify this
             _      (assert (instance? PoshableConnection conn))]
         (try (let [txn-report (db/transact! conn (install-partition default-partition))

--- a/src/posh/lib/datomic.clj
+++ b/src/posh/lib/datomic.clj
@@ -1,0 +1,48 @@
+(ns posh.lib.datomic
+  "General Datomic utils."
+  (:require [datomic.api      :as d]
+            [posh.clj.datomic :as db])
+  (:import posh.clj.datomic.PoshableConnection))
+
+(def default-partition :db.part/default)
+
+(defn tempid [] (d/tempid default-partition))
+
+(defn install-partition [part]
+  (let [id (d/tempid :db.part/db)]
+    [{:db/id    id
+      :db/ident part}
+     [:db/add               :db.part/db
+      :db.install/partition id]]))
+
+(defn transact-schemas!
+  "This is used because, perhaps very strangely, schema changes to Datomic happen
+   asynchronously."
+  {:todo #{"Make more robust"}}
+  [conn schemas]
+  (let [txn-report (db/transact! conn
+                     (->> schemas
+                          (map #(assoc % :db/id (d/tempid :db.part/db)
+                                         :db.install/_attribute :db.part/db))))
+        txn-id     (-> txn-report :tx-data first (get 3))
+        _ #_(deref (d/sync (db/->conn conn) (java.util.Date. (System/currentTimeMillis))) 500 nil)
+            (deref (d/sync-schema (db/->conn conn) (inc txn-id)) 500 nil)] ; frustratingly, doesn't even work with un-`inc`ed txn-id
+    txn-report))
+
+(defn with-conn [uri f]
+  (try (d/create-database uri)
+       (let [conn (d/connect uri)]
+         (try (f conn)
+           (finally (d/release conn))))
+    (finally (d/delete-database uri))))
+
+(defn with-posh-conn [uri schemas f]
+  (with-conn uri
+    (fn [conn*]
+      (let [poshed (db/posh! conn*) ; This performs a `with-meta` so the result is needed
+            conn   (-> poshed :conns :conn0) ; Has the necessary meta ; TODO simplify this
+            _      (assert (instance? PoshableConnection conn))]
+        (try (let [txn-report (db/transact! conn (install-partition default-partition))
+                   txn-report (transact-schemas! conn schemas)]
+               (f conn))
+          (finally (db/stop conn))))))) ; TODO `unposh!`

--- a/src/posh/lib/datomic.clj
+++ b/src/posh/lib/datomic.clj
@@ -1,12 +1,101 @@
 (ns posh.lib.datomic
   "General Datomic utils."
   (:require [datomic.api      :as d]
-            [posh.clj.datomic :as db])
-  (:import posh.clj.datomic.PoshableConnection))
+            [clojure.core.async :as async
+              :refer [thread offer! <!! promise-chan]]
+            [posh.plugin-base :as base]
+            [posh.lib.util    :as u
+              :refer [debug]]))
+
+; TODO import stuartsierra.component ?
+; TODO move
+(defprotocol Lifecycle
+  (start [this])
+  (stop  [this]))
+
+#_(defn datom->seq [^datomic.Datom d] [(.e d) (.a d) (.v d) (.tx d) (.added d)])
+
+(defn datom->seq [db-after ^datomic.Datom d]
+  [(.e d) (d/ident db-after (.a d)) (.v d) (.tx d) (.added d)])
+
+(extend-type datomic.Datom
+  clojure.core.protocols/CollReduce
+  (coll-reduce [datom f  ] (reduce f (f) (datom->seq datom)))
+  (coll-reduce [datom f v] (reduce f v   (datom->seq datom))))
+
+(defn normalized-tx-report [{:keys [db-after] :as tx-report}]
+  (update tx-report :tx-data
+    (fn [datoms] (mapv #(datom->seq db-after %) datoms))))
+
+(defn run-listeners! [pconn tx-report']
+  (try (doseq [[_ callback] @(:listeners pconn)] (callback tx-report'))
+       (catch Throwable e (debug "WARNING:" e))))
+
+(defrecord PoshableConnection [datomic-conn listeners deduplicate-tx-idents interrupted?]
+  Lifecycle
+  (start [this]
+    (assert (instance? datomic.Connection datomic-conn))
+    (assert (instance? clojure.lang.IAtom listeners))
+    (assert (instance? clojure.lang.IAtom interrupted?))
+    ; See `transact!*` as to why the below schema+entity is required.
+    ; TODO use `posh.lib.datomic/transact-schemas!`?
+    @(d/transact datomic-conn
+       [{:db/id                 (d/tempid :db.part/db)
+         :db.install/_attribute :db.part/db
+         :db/ident              :posh.clj.datomic.tx-notifier/value
+         :db/cardinality        :db.cardinality/one
+         :db/valueType          :db.type/uuid}
+        {:db/id    (d/tempid :db.part/db)
+         :db/ident ::tx-notifier}])
+    (thread
+      (loop []
+        (when-not @interrupted?
+                     ; `poll` because if `take`, still won't be nil or stop waiting when conn is released
+                     ; the poll time is how long it will take to shut down when that time comes
+          (when-let [{:keys [db-after] :as tx-report}
+                       (.poll ^java.util.concurrent.BlockingQueue
+                              (d/tx-report-queue datomic-conn)
+                              1
+                              java.util.concurrent.TimeUnit/SECONDS)]
+            (try (let [{:keys [tx-data] :as tx-report'} (normalized-tx-report tx-report)
+                       last-tx-item (last tx-data)
+                       tx-ident (when (and last-tx-item
+                                           (= (d/ident db-after (get last-tx-item 0)) ::tx-notifier)
+                                           (= (d/ident db-after (get last-tx-item 1)) :posh.clj.datomic.tx-notifier/value))
+                                  (get last-tx-item 2))]
+                   (try (debug "tx-report received in PoshableConnection")
+                        (when-not (get @deduplicate-tx-idents tx-ident)
+                          (run-listeners! this tx-report'))
+                     (finally
+                       (swap! deduplicate-tx-idents #(disj % tx-ident)))))
+              (catch Throwable e (debug "WARNING:" e)))
+            (recur)))))
+    this)
+  (stop [this]
+    (reset! interrupted? true)
+    (swap! deduplicate-tx-idents empty)
+    this))
+
+(defn conn? [x] (instance? PoshableConnection x))
+
+(defn ->poshable-conn [datomic-conn]
+  {:pre [(instance? datomic.Connection datomic-conn)]}
+  (let [listeners (atom nil)]
+    (with-meta (start (PoshableConnection. datomic-conn listeners (atom #{}) (atom false)))
+               {:listeners listeners})))
+
+(defn listen!
+  ([conn callback] (listen! conn (gensym) callback))
+  ([conn key callback]
+    {:pre [(conn? conn)]}
+    (swap! (:listeners (meta conn)) assoc key callback)
+    key))
 
 (def default-partition :db.part/default)
 
 (defn tempid [] (d/tempid default-partition))
+
+(defn ->conn [x] (if (conn? x) (:datomic-conn x) x))
 
 (defn install-partition [part]
   (let [id (d/tempid :db.part/db)]
@@ -15,19 +104,52 @@
      [:db/add               :db.part/db
       :db.install/partition id]]))
 
+(defn transact!*
+  "The main point of the additions onto Datomic's base `transact` fn is to wait for related
+   listeners to be run before returning."
+  [conn tx]
+  {:pre [(conn? conn)]}
+  (let [; In order to ensure listeners are run only once (i.e. deduplicate them),
+        ; we have to transmit to the report queue in a race-condition-free way
+        ; some sort of unique ID we know ahead of time. I'd like to just use the
+        ; txn ID, but this is not given ahead of time. Thus we must pass a squuid
+        ; to the transaction.
+        ; This is cleaner than e.g. using channels because they introduce race
+        ; conditions in this situation.
+        tx-ident   (d/squuid)
+        _          (swap! (:deduplicate-tx-idents conn) conj tx-ident)
+        tx-report  @(d/transact (->conn conn)
+                      (conj (vec tx) [:db/add ::tx-notifier :posh.clj.datomic.tx-notifier/value tx-ident]))
+        tx-report' (normalized-tx-report tx-report)
+        _          (run-listeners! conn tx-report')]
+    tx-report'))
+
 (defn transact-schemas!
   "This is used because, perhaps very strangely, schema changes to Datomic happen
    asynchronously."
   {:todo #{"Make more robust"}}
-  [conn schemas]
-  (let [txn-report (db/transact! conn
+  [dcfg conn schemas]
+  (let [txn-report (base/transact! dcfg conn
                      (->> schemas
-                          (map #(assoc % :db/id (d/tempid :db.part/db)
-                                         :db.install/_attribute :db.part/db))))
+                          (map (fn [[ident v]] (assoc v :db/ident ident
+                                                        :db/id    (d/tempid :db.part/db)
+                                                        :db.install/_attribute :db.part/db)))))
         txn-id     (-> txn-report :tx-data first (get 3))
-        _ #_(deref (d/sync (db/->conn conn) (java.util.Date. (System/currentTimeMillis))) 500 nil)
-            (deref (d/sync-schema (db/->conn conn) (inc txn-id)) 500 nil)] ; frustratingly, doesn't even work with un-`inc`ed txn-id
+        _ #_(deref (d/sync (->conn conn) (java.util.Date. (System/currentTimeMillis))) 500 nil)
+            (deref (d/sync-schema (->conn conn) (inc txn-id)) 500 nil)] ; frustratingly, doesn't even work with un-`inc`ed txn-id
     txn-report))
+
+(defn db* [x]
+  (cond (instance? datomic.Database x)
+        x
+        (conn? x)
+        (-> x :datomic-conn d/db)
+        (instance? datomic.Connection x)
+        (d/db x)
+        :else x #_(throw (ex-info "Object cannot be converted into DB" {:obj x}))))
+
+(defn q* [q x & args]
+  (apply d/q q (db* x) args))
 
 (defn with-conn [uri f]
   (try (d/create-database uri)
@@ -36,13 +158,13 @@
            (finally (d/release conn))))
     (finally (d/delete-database uri))))
 
-(defn with-posh-conn [retrieve uri schemas f]
+(defn with-posh-conn [dcfg retrieve uri schemas f]
   (with-conn uri
     (fn [conn*]
-      (let [poshed (db/posh-one! conn* retrieve) ; This performs a `with-meta` so the result is needed
-            conn   (-> poshed :conns :conn0) ; Has the necessary meta ; TODO simplify this
+      (let [poshed (base/posh-one! dcfg conn* retrieve) ; This performs a `with-meta` so the result is needed
+            conn   (-> poshed deref :conns :conn0) ; Has the necessary meta ; TODO simplify this
             _      (assert (instance? PoshableConnection conn))]
-        (try (let [txn-report (db/transact! conn (install-partition default-partition))
-                   txn-report (transact-schemas! conn schemas)]
-               (f conn))
-          (finally (db/stop conn))))))) ; TODO `unposh!`
+        (try (let [txn-report (base/transact! dcfg conn (install-partition default-partition))
+                   txn-report (transact-schemas! dcfg conn schemas)]
+               (f poshed conn))
+          (finally (stop conn))))))) ; TODO `unposh!`

--- a/src/posh/lib/db.cljc
+++ b/src/posh/lib/db.cljc
@@ -53,7 +53,7 @@
            db (if with (:db-after ((:with dcfg) db with)) db)  ;; with tx-data
            db (if filter
                 ((:filter dcfg) db (if (symbol? filter)
-                                     #?(:clj (resolve filter) :cljs nil)
+                                     #?(:clj (resolve filter) :cljs nil) ; TODO why use resolve?
                                      filter))
                 db) ;; filter pred-sym
            ]

--- a/src/posh/lib/ratom.cljc
+++ b/src/posh/lib/ratom.cljc
@@ -1,7 +1,9 @@
 (ns posh.lib.ratom
   "Ported to .cljc from reagent.ratom by alexandergunnarson."
            (:refer-clojure :exclude [atom run!])
-           (:require        [clojure.set           :as s])
+           (:require        [clojure.set           :as s]
+                            [posh.lib.util
+                              :refer [#?(:clj if-cljs)]])
   #?(:cljs (:require-macros [posh.lib.ratom
                               :refer [getm setm! getf setf! add! array-list alength* aset* aget*]]))
   #?(:clj  (:import         [java.util ArrayList]
@@ -10,17 +12,6 @@
 ;;; Misc utils
 
 (defn upper-first [s] (apply str (.toUpperCase (str (first s))) (rest s)))
-
-(defn cljs-env?
-  "Given an &env from a macro, tells whether it is expanding into CLJS."
-  [env]
-  (boolean (:ns env)))
-
-#?(:clj
-(defmacro if-cljs
-  "Return @then if the macro is generating CLJS code and @else for CLJ code."
-  {:from "https://groups.google.com/d/msg/clojurescript/iBY5HaQda4A/w1lAQi9_AwsJ"}
-  ([env then else] `(if (cljs-env? ~env) ~then ~else))))
 
 ;;; Mutability
 

--- a/src/posh/lib/ratom.cljc
+++ b/src/posh/lib/ratom.cljc
@@ -247,7 +247,7 @@
   (when (nil? (getm rea-queue))
     (setm! rea-queue (array-list))
     #_(:cljs (reagent.impl.batching/schedule)))
-  (add! (getm rea-queue) r))
+  (let [x (getm rea-queue)] (add! x r))) ; For anti-reflection
 
 (defn flush! []
   (loop []

--- a/src/posh/lib/ratom.cljc
+++ b/src/posh/lib/ratom.cljc
@@ -5,9 +5,17 @@
                             [posh.lib.util
                               :refer [#?(:clj if-cljs)]])
   #?(:cljs (:require-macros [posh.lib.ratom
-                              :refer [getm setm! getf setf! add! array-list alength* aset* aget*]]))
+                              :refer [getm setm! getum setum! getf setf! add! array-list alength* aset* aget* umut]]))
   #?(:clj  (:import         [java.util ArrayList]
                             [clojure.lang IDeref IAtom IRef IMeta IHashEq])))
+
+; According to `posh.lib.ratom-test/ratom-perf`,
+; the unsynchronized-mutable CLJ version takes ~177.315377 ms, while
+; the clojure.core/atom version takes ~345.78108 ms
+
+; If you want to use mutability here, you need to make sure all transacts (really, listener updates)
+; and all derefs are on the same thread. Changing the appropriate macros is pretty easy — much more
+; so than changing all the places where the macro affects.
 
 ;;; Misc utils
 
@@ -29,21 +37,51 @@
   IDeref
   (deref [this] val)))
 
-#?(:clj (defmacro mut [x] `(Mutable. ~x)))
+#?(:clj (defmacro mut "Mutable" [x] #_`(Mutable. ~x)
+                                   `(clojure.core/atom ~x)))
+
+#?(:clj (defmacro umut "Unsynchronized mutable" [x]
+          (if-cljs &env x `(clojure.core/atom ~x))))
 
 #?(:clj
 (defmacro getm
   "Get mutable"
   [x]
   (if-cljs &env x
-                `(.get ~(with-meta x {:tag 'posh.lib.ratom.Mutable})))))
+                #_`(.get ~(with-meta x {:tag 'posh.lib.ratom.Mutable}))
+                `(deref ~x))))
 
 #?(:clj
 (defmacro setm!
   "Set mutable"
   [x v]
   (if-cljs &env `(set!            ~x                                        ~v)
-                `(.set ~(with-meta x {:tag 'posh.lib.ratom.Mutable}) ~v))))
+                #_`(.set ~(with-meta x {:tag 'posh.lib.ratom.Mutable}) ~v)
+                `(reset! ~x ~v))))
+
+#?(:clj
+(defmacro getum
+  "Get unsynchronized-mutable"
+  [x]
+  (if-cljs &env x
+                #_x
+                `(deref ~x))))
+
+#?(:clj
+(defmacro getum*
+  "Get unsynchronized-mutable, handling nil"
+  [x]
+  (if-cljs &env x
+                #_x
+                `(let [x# ~x] (if (nil? x#) x# (deref x#))))))
+
+#?(:clj
+(defmacro setum!
+  "Set unsynchronized-mutable"
+  [x v]
+  (if-cljs &env `(set!   ~x ~v)
+                #_`(set! ~x ~v)
+                `(reset! ~x ~v))))
 
 #?(:clj
 (defmacro getf
@@ -69,27 +107,32 @@
 #?(:clj
 (defmacro add! [x v]
   (if-cljs &env `(.push ~x ~v)
-                `(.add ~(with-meta x {:tag 'java.util.ArrayList}) ~v))))
+                #_`(.add ~(with-meta x {:tag 'java.util.ArrayList}) ~v)
+                `(swap! ~x conj ~v))))
 
 #?(:clj
 (defmacro array-list [& args]
   (if-cljs &env `(array ~@args)
-                `(doto (ArrayList.) ~@(for [arg args] `(.add ~arg))))))
+                #_`(doto (ArrayList.) ~@(for [arg args] `(.add ~arg)))
+                `(clojure.core/atom [~@args]))))
 
 #?(:clj
 (defmacro alength* [x]
   (if-cljs &env `(alength ~x)
-                `(.size ~(with-meta x {:tag 'java.util.ArrayList})))))
+                #_`(.size ~(with-meta x {:tag 'java.util.ArrayList}))
+                `(count (deref ~x)))))
 
 #?(:clj
 (defmacro aget* [x i]
   (if-cljs &env `(aget ~x)
-                `(.get ~(with-meta x {:tag 'java.util.ArrayList}) ~i))))
+                #_`(.get ~(with-meta x {:tag 'java.util.ArrayList}) ~i)
+                `(get (deref ~x) ~i))))
 
 #?(:clj
 (defmacro aset* [x i v]
   (if-cljs &env `(aset ~x ~i ~v)
-                `(.set ~(with-meta x {:tag 'java.util.ArrayList}) ~i ~v))))
+                #_`(.set ~(with-meta x {:tag 'java.util.ArrayList}) ~i ~v)
+                `(swap! ~x assoc ~i ~v))))
 
 ;;; Interfaces and (certain) types
 
@@ -100,10 +143,10 @@
 
 #?(:clj
 (deftype HasCaptured
-  [^:unsynchronized-mutable captured]
+  [^:mutable captured]
   IHasCaptured
-  (getCaptured [this] captured)
-  (setCaptured [this v] (set! captured v))))
+  (getCaptured [this] (getum captured))
+  (setCaptured [this v] (setum! captured v))))
 
 #?(:clj
 (definterface IHasWatches
@@ -213,7 +256,7 @@
         a (if (nil? w)
             ;; Copy watches to array(-list) for speed
             (->> (getf this watches)
-                 (reduce-kv #(doto %1 (add! %2) (add! %3)) #?(:clj (ArrayList.) :cljs #js[]))
+                 (reduce-kv #(doto %1 (add! %2) (add! %3)) (array-list))
                  (setf! this watchesArr))
             w)]
     (let [len (alength* a)]
@@ -258,11 +301,11 @@
 (defprotocol IReactiveAtom)
 
 (deftype RAtom
-  #?(:clj  [^:unsynchronized-mutable state
+  #?(:clj  [^:mutable state
             meta
             validator
-            ^:unsynchronized-mutable watches
-            ^:unsynchronized-mutable watchesArr]
+            ^:mutable watches
+            ^:mutable watchesArr]
      :cljs [^:mutable state
             meta
             validator
@@ -277,23 +320,23 @@
   IDeref
   (#?(:clj deref :cljs -deref) [this]
     (notify-deref-watcher! this)
-    state)
+    (getum state))
 
   #?(:clj IAtom :cljs IReset)
   (#?(:clj reset :cljs -reset!) [a new-value]
     (when-not (nil? validator)
       (assert (validator new-value) "Validator rejected reference state"))
     (let [old-value state]
-      (set! state new-value)
-      (when-not (nil? watches)
+      (setum! state new-value)
+      (when-not (nil? (getum watches))
         (notify-w a old-value new-value))
       new-value))
 
   #?(:cljs ISwap)
-  (#?(:clj swap :cljs -swap!) [a f]          (#?(:clj .reset :cljs -reset!) a (f state)))
-  (#?(:clj swap :cljs -swap!) [a f x]        (#?(:clj .reset :cljs -reset!) a (f state x)))
-  (#?(:clj swap :cljs -swap!) [a f x y]      (#?(:clj .reset :cljs -reset!) a (f state x y)))
-  (#?(:clj swap :cljs -swap!) [a f x y more] (#?(:clj .reset :cljs -reset!) a (apply f state x y more)))
+  (#?(:clj swap :cljs -swap!) [a f]          (#?(:clj .reset :cljs -reset!) a (f (getum state))))
+  (#?(:clj swap :cljs -swap!) [a f x]        (#?(:clj .reset :cljs -reset!) a (f (getum state) x)))
+  (#?(:clj swap :cljs -swap!) [a f x y]      (#?(:clj .reset :cljs -reset!) a (f (getum state) x y)))
+  (#?(:clj swap :cljs -swap!) [a f x y more] (#?(:clj .reset :cljs -reset!) a (apply f (getum state) x y more)))
 
   IMeta
   (#?(:clj meta :cljs -meta) [_] meta)
@@ -311,15 +354,15 @@
 
   #?@(:clj
  [IHasWatches
-  (getWatches    [this]   watches)
-  (setWatches    [this v] (set! watches v))
-  (getWatchesArr [this]   watchesArr)
-  (setWatchesArr [this v] (set! watchesArr v))]))
+  (getWatches    [this]   (getum watches))
+  (setWatches    [this v] (setum! watches v))
+  (getWatchesArr [this]   (getum watchesArr))
+  (setWatchesArr [this v] (setum! watchesArr v))]))
 
 (defn atom
   "Like clojure.core/atom, except that it keeps track of derefs."
-  ([x] (RAtom. x nil nil nil nil))
-  ([x & {:keys [meta validator]}] (RAtom. x meta validator nil nil)))
+  ([x] (RAtom. (umut x) nil nil (umut nil) (umut nil)))
+  ([x & {:keys [meta validator]}] (RAtom. (umut x) meta validator (umut nil) (umut nil))))
 
 ;;; track
 
@@ -356,39 +399,39 @@
   (getArgs [])))
 
 (deftype Track
-  #?(:clj  [^:unsynchronized-mutable f args
-            ^:unsynchronized-mutable reaction]
+  #?(:clj  [^:mutable f args
+            ^:mutable reaction]
      :cljs [f args ^:mutable reaction])
   IReactiveAtom
 
   IDeref
   (#?(:clj deref :cljs -deref) [this]
-    (if-some [^IDeref r reaction]
+    (if-some [^IDeref r (getum reaction)]
       (#?(:clj .deref :cljs -deref) r)
-      (cached-reaction #(apply f args) f args this nil)))
+      (cached-reaction #(apply (getum f) args) (getum f) args this nil)))
 
   #?(:clj Object :cljs IEquiv)
   (#?(:clj equals :cljs -equiv) [_ other]
     (and (instance? Track other)
-         (= f (getf ^Track other f))
+         (= (getum f) (getf ^Track other f))
          (= args (getf ^Track other args))))
 
   #?(:clj IHashEq :cljs IHash)
-  (#?(:clj hasheq :cljs -hash) [_] (hash [f args]))
+  (#?(:clj hasheq :cljs -hash) [_] (hash [(getum f) args]))
 
   #?(:cljs IPrintWithWriter)
   #?(:cljs (-pr-writer [a w opts] (pr-atom a w opts "Track:")))
 
   #?@(:clj
  [IHasF
-  (getF    [this]   f)
-  (setF    [this v] (set! f v))
+  (getF    [this]   (getum f))
+  (setF    [this v] (setum! f v))
 
   ITrack
   (getArgs [this]   args)]))
 
 (defn make-track [f args]
-  (Track. f args nil))
+  (Track. (umut f) args (umut nil)))
 
 (defn make-track! [f args]
   (let [^Track t (make-track f args)
@@ -416,9 +459,9 @@
 
 (deftype RCursor
   #?(:clj  [ratom path
-            ^:unsynchronized-mutable reaction
-            ^:unsynchronized-mutable state
-            ^:unsynchronized-mutable watches]
+            ^:mutable reaction
+            ^:mutable state
+            ^:mutable watches]
      :cljs [ratom path
             ^:mutable reaction
             ^:mutable state
@@ -439,8 +482,8 @@
 
   (setState [this oldstate newstate]
     (when-not (identical? oldstate newstate)
-      (set! state newstate)
-      (when (some? watches)
+      (setum! state newstate)
+      (when (some? (getum watches))
         (notify-w this oldstate newstate))))
 
   #?@(:clj
@@ -449,8 +492,8 @@
 
   IDeref
   (#?(:clj deref :cljs -deref) [this]
-    (let [oldstate state
-          newstate (if-some [^IDeref r reaction]
+    (let [oldstate (getum state)
+          newstate (if-some [^IDeref r (getum reaction)]
                      (#?(:clj .deref :cljs -deref) r)
                      (let [f (if (satisfies? IDeref ratom)
                                #(get-in @ratom path)
@@ -461,7 +504,7 @@
 
   #?(:clj IAtom :cljs IReset)
   (#?(:clj reset :cljs -reset!) [this new-value]
-    (let [oldstate state]
+    (let [oldstate (getum state)]
       (.setState this oldstate new-value)
       (if (satisfies? IDeref ratom)
         (if (= path [])
@@ -494,8 +537,7 @@
                    (not (vector? src))))
           (str "src must be a reactive atom or a function, not "
                (pr-str src)))
-  (RCursor. src path nil nil nil))
-
+  (RCursor. src path (umut nil) (umut nil) (umut nil)))
 
 ;;; with-let support
 
@@ -522,20 +564,20 @@
 (declare handle-reaction-change)
 
 (deftype Reaction
-  #?(:clj  [^:unsynchronized-mutable f
-            ^:unsynchronized-mutable state
-            ^:unsynchronized-mutable dirty?
-            ^:unsynchronized-mutable no-cache?
-            ^:unsynchronized-mutable watching
-            ^:unsynchronized-mutable watches
-            ^:unsynchronized-mutable autoRun
-            ^:unsynchronized-mutable caught
-            ^:unsynchronized-mutable on-set
-            ^:unsynchronized-mutable on-dispose
-            ^:unsynchronized-mutable on-dispose-arr
-            ^:unsynchronized-mutable captured
-            ^:unsynchronized-mutable ratomGeneration
-            ^:unsynchronized-mutable watchesArr]
+  #?(:clj  [^:mutable f
+            ^:mutable state
+            ^:mutable dirty?
+            ^:mutable no-cache?
+            ^:mutable watching
+            ^:mutable watches
+            ^:mutable autoRun
+            ^:mutable caught
+            ^:mutable on-set
+            ^:mutable on-dispose
+            ^:mutable on-dispose-arr
+            ^:mutable captured
+            ^:mutable ratomGeneration
+            ^:mutable watchesArr]
      :cljs [f ^:mutable state
             ^:mutable
             ^boolean dirty?
@@ -557,19 +599,19 @@
   #?(:cljs (-notify-watches [this old new] (notify-w this old new))) ; TODO CLJ
   (#?(:clj addWatch    :cljs -add-watch   ) [this key f]        (add-w this key f))
   (#?(:clj removeWatch :cljs -remove-watch) [this key]
-    (let [was-empty (empty? watches)]
+    (let [was-empty (empty? (getum watches))]
       (remove-w this key)
       (when (and (not was-empty)
-                 (empty? watches)
-                 (nil? autoRun))
+                 (empty? (getum watches))
+                 (nil? (getum autoRun)))
         (#?(:clj .dispose :cljs dispose) this))))
 
   #?(:clj IAtom :cljs IReset)
   (#?(:clj reset :cljs -reset!) [a newval]
-    (assert (fn? (.-on-set a)) "Reaction is read only.")
-    (let [oldval state]
-      (set! state newval)
-      (on-set oldval newval)
+    (assert (fn? (getum on-set)) "Reaction is read only.")
+    (let [oldval (getum state)]
+      (setum! state newval)
+      ((getum on-set) oldval newval)
       (notify-w a oldval newval)
       newval))
 
@@ -586,47 +628,47 @@
 
   (handleChange [this sender oldval newval]
     (when-not (or (identical? oldval newval)
-                  dirty?)
-      (if (nil? autoRun)
+                  (getum dirty?))
+      (if (nil? (getum autoRun))
         (do
-          (set! dirty? true)
+          (setum! dirty? true)
           (rea-enqueue this))
-        (if (true? autoRun)
+        (if (true? (getum autoRun))
           (.run this false)
-          (autoRun this)))))
+          ((getum autoRun) this)))))
 
   (updateWatching [this derefed]
     (let [new (set derefed)
-          old (set watching)]
-      (set! watching derefed)
+          old (set (getum watching))]
+      (setum! watching derefed)
       (doseq [#?(:clj ^IRef w :cljs w) (s/difference new old)]
         (#?(:clj .addWatch :cljs -add-watch) w this handle-reaction-change))
       (doseq [#?(:clj ^IRef w :cljs w) (s/difference old new)]
         (#?(:clj .removeWatch :cljs -remove-watch) w this))))
 
   (queuedRun [this]
-    (when (and dirty? (some? watching))
+    (when (and (getum dirty?) (some? (getum watching)))
       (.run this true)))
 
   (tryCapture [this f]
     (try
-      (set! caught nil)
+      (setum! caught nil)
       (deref-capture f this)
       (catch #?(:clj Throwable :cljs :default) e
-        (set! state e)
-        (set! caught e)
-        (set! dirty? false))))
+        (setum! state e)
+        (setum! caught e)
+        (setum! dirty? false))))
 
   (run [this check]
-    (let [oldstate state
+    (let [oldstate (getum state)
           res (if check
-                (.tryCapture this f)
-                (deref-capture f this))]
-      (when-not no-cache?
-        (set! state res)
+                (.tryCapture this (getum f))
+                (deref-capture (getum f) this))]
+      (when-not (getum no-cache?)
+        (setum! state res)
         ;; Use = to determine equality from reactions, since
         ;; they are likely to produce new data structures.
-        (when-not (or (nil? watches)
+        (when-not (or (nil? (getum watches))
                       (= oldstate res))
           (notify-w this oldstate res)))
       res))
@@ -637,37 +679,37 @@
           on-dispose* (:on-dispose opts)
           no-cache*   (:no-cache   opts)]
       (when (some? auto-run*)
-        (set! autoRun auto-run*))
+        (setum! autoRun auto-run*))
       (when (some? on-set*)
-        (set! on-set on-set*))
+        (setum! on-set on-set*))
       (when (some? on-dispose*)
-        (set! on-dispose on-dispose*))
+        (setum! on-dispose on-dispose*))
       (when (some? no-cache*)
-        (set! no-cache? no-cache*))))
+        (setum! no-cache? no-cache*))))
 
   #?@(:clj
- [(getRatomGeneration [this]   ratomGeneration)
-  (setRatomGeneration [this v] (set! ratomGeneration v))
-  (getIsDirty         [this]   dirty?)
-  (setIsDirty         [this v] (set! dirty? v))
-  (getWatching        [this]   watching)
-  (setWatching        [this v] (set! watching v))
-  (getAutoRun         [this]   autoRun)
-  (setAutoRun         [this v] (set! autoRun v))
+ [(getRatomGeneration [this]   (getum ratomGeneration))
+  (setRatomGeneration [this v] (setum! ratomGeneration v))
+  (getIsDirty         [this]   (getum dirty?))
+  (setIsDirty         [this v] (setum! dirty? v))
+  (getWatching        [this]   (getum watching))
+  (setWatching        [this v] (setum! watching v))
+  (getAutoRun         [this]   (getum autoRun))
+  (setAutoRun         [this v] (setum! autoRun v))
 
   IHasF
-  (getF               [this]   f)
-  (setF               [this v] (set! f v))
+  (getF               [this]   (getum f))
+  (setF               [this v] (setum! f v))
 
   IHasCaptured
-  (getCaptured        [this]   captured)
-  (setCaptured        [this v] (set! captured v))
+  (getCaptured        [this]   (getum captured))
+  (setCaptured        [this v] (setum! captured v))
 
   IHasWatches
-  (getWatches    [this]   watches)
-  (setWatches    [this v] (set! watches v))
-  (getWatchesArr [this]   watchesArr)
-  (setWatchesArr [this v] (set! watchesArr v))])
+  (getWatches    [this]   (getum watches))
+  (setWatches    [this v] (setum! watches v))
+  (getWatchesArr [this]   (getum watchesArr))
+  (setWatchesArr [this v] (setum! watchesArr v))])
 
   IRunnable
   (run [this]
@@ -676,43 +718,43 @@
 
   IDeref
   (#?(:clj deref :cljs -deref) [this]
-    (when-some [e caught]
+    (when-some [e (getum caught)]
       (throw e))
     (let [non-reactive (nil? *ratom-context*)]
       (when non-reactive
         (flush!))
-      (if (and non-reactive (nil? autoRun))
-        (when dirty?
-          (let [oldstate state]
-            (set! state (f))
-            (when-not (or (nil? watches) (= oldstate state))
-              (notify-w this oldstate state))))
+      (if (and non-reactive (nil? (getum autoRun)))
+        (when (getum dirty?)
+          (let [oldstate (getum state)]
+            (setum! state ((getum f)))
+            (when-not (or (nil? (getum watches)) (= oldstate (getum state)))
+              (notify-w this oldstate (getum state)))))
         (do
           (notify-deref-watcher! this)
-          (when dirty?
+          (when (getum dirty?)
             (.run this false)))))
-    state)
+    (getum state))
 
   IDisposable
   (dispose [this]
-    (let [s state
-          wg watching]
-      (set! watching nil)
-      (set! state    nil)
-      (set! autoRun  nil)
-      (set! dirty?   true)
+    (let [s (getum state)
+          wg (getum watching)]
+      (setum! watching nil)
+      (setum! state    nil)
+      (setum! autoRun  nil)
+      (setum! dirty?   true)
       (doseq [#?(:clj ^IRef w :cljs w) (set wg)]
         (#?(:clj .removeWatch :cljs -remove-watch) w this))
-      (when (some? on-dispose)
-        (on-dispose s))
-      (when-some [a on-dispose-arr]
+      (when (some? (getum on-dispose))
+        ((getum on-dispose) s))
+      (when-some [a (getum on-dispose-arr)]
         (dotimes [i (alength* a)]
           ((aget* a i) this)))))
   (addOnDispose [this f]
     ;; f is called with the reaction as argument when it is no longer active
-    (if-some [a on-dispose-arr]
+    (if-some [a (getum on-dispose-arr)]
       (add! a f)
-      (set! on-dispose-arr (array-list f))))
+      (setum! on-dispose-arr (array-list f))))
 
   #?(:clj Object :cljs IEquiv)
   (#?(:clj equals :cljs -equiv) [o other] (identical? o other))
@@ -731,7 +773,7 @@
   (when (dev?)
     (setf! r ratomGeneration (setm! generation (inc generation))))
   (let [res (in-context r f)
-        c (getf r captured)]
+        c   (getum* (getf r captured))] ; `getum*` because it'll be an `array-list`
     (setf! r #?(:clj isDirty :cljs dirty?) false)
     ;; Optimize common case where derefs occur in same order
     (when-not (#?(:clj = :cljs arr-eq) c (getf r watching))
@@ -739,7 +781,9 @@
     res))
 
 (defn make-reaction [f & {:keys [auto-run on-set on-dispose]}]
-  (let [reaction (Reaction. f nil true false nil nil nil nil nil nil nil nil nil nil)]
+  (let [reaction (Reaction. (umut f  ) (umut nil) (umut true) (umut false) (umut nil) (umut nil)
+                            (umut nil) (umut nil) (umut nil ) (umut nil  ) (umut nil) (umut nil)
+                            (umut nil) (umut nil))]
     (.setOpts reaction {:auto-run   auto-run
                         :on-set     on-set
                         :on-dispose on-dispose})
@@ -775,9 +819,9 @@
   (setChanged  [v])))
 
 (deftype Wrapper
-  #?(:clj  [^:unsynchronized-mutable state callback
-            ^:unsynchronized-mutable changed
-            ^:unsynchronized-mutable watches]
+  #?(:clj  [^:mutable state callback
+            ^:mutable changed
+            ^:mutable watches]
      :cljs [^:mutable state callback
             ^:mutable ^boolean changed
             ^:mutable watches])
@@ -786,35 +830,35 @@
   IDeref
   (#?(:clj deref :cljs -deref) [this]
     (when (dev?)
-      (when (and changed (some? *ratom-context*))
+      (when (and (getum changed) (some? *ratom-context*))
         (#?(:clj println :cljs warn) "derefing stale wrap: "
               (pr-str this))))
-    state)
+    (getum state))
 
   #?(:clj IAtom :cljs IReset)
   (#?(:clj reset :cljs -reset!) [this newval]
-    (let [oldval state]
-      (set! changed true)
-      (set! state newval)
-      (when (some? watches)
+    (let [oldval (getum state)]
+      (setum! changed true)
+      (setum! state newval)
+      (when (some? (getum watches))
         (notify-w this oldval newval))
       (callback newval)
       newval))
 
   #?(:cljs ISwap)
-  (#?(:clj swap :cljs -swap!) [a f]          (#?(:clj .reset :cljs -reset!) a (f state)))
-  (#?(:clj swap :cljs -swap!) [a f x]        (#?(:clj .reset :cljs -reset!) a (f state x)))
-  (#?(:clj swap :cljs -swap!) [a f x y]      (#?(:clj .reset :cljs -reset!) a (f state x y)))
-  (#?(:clj swap :cljs -swap!) [a f x y more] (#?(:clj .reset :cljs -reset!) a (apply f state x y more)))
+  (#?(:clj swap :cljs -swap!) [a f]          (#?(:clj .reset :cljs -reset!) a (f (getum state))))
+  (#?(:clj swap :cljs -swap!) [a f x]        (#?(:clj .reset :cljs -reset!) a (f (getum state) x)))
+  (#?(:clj swap :cljs -swap!) [a f x y]      (#?(:clj .reset :cljs -reset!) a (f (getum state) x y)))
+  (#?(:clj swap :cljs -swap!) [a f x y more] (#?(:clj .reset :cljs -reset!) a (apply f (getum state) x y more)))
 
   #?(:clj Object :cljs IEquiv)
   (#?(:clj equals :cljs -equiv) [_ other]
     (and (instance? Wrapper other)
          ;; If either of the wrappers have changed, equality
          ;; cannot be relied on.
-         (not changed)
+         (not (getum changed))
          (not (getf ^Wrapper other changed))
-         (= state (getf ^Wrapper other state))
+         (= (getum state) (getf ^Wrapper other state))
          (= callback (getf ^Wrapper other callback))))
 
   #?(:clj IRef :cljs IWatchable)
@@ -827,17 +871,17 @@
 
   #?@(:clj
  [IWrapper
-  (getState    [this]   state)
-  (setState    [this v] (set! state v))
+  (getState    [this]   (getum state))
+  (setState    [this v] (setum! state v))
   (getCallback [this]   callback)
-  (getChanged  [this]   changed)
-  (setChanged  [this v] (set! changed v))]))
+  (getChanged  [this]   (getum changed))
+  (setChanged  [this v] (setum! changed v))]))
 
 #_(:cljs
 (defn make-wrapper [value callback-fn args]
-  (Wrapper. value
+  (Wrapper. (umut value)
             (reagent.impl.util/partial-ifn. callback-fn args nil)
-            false nil)))
+            (umut false) (umut nil))))
 
 #?(:cljs ; TODO CLJ
 (defn rswap!

--- a/src/posh/lib/ratom.cljc
+++ b/src/posh/lib/ratom.cljc
@@ -303,16 +303,11 @@
 (defprotocol IReactiveAtom)
 
 (deftype RAtom
-  #?(:clj  [^:mutable state
-            meta
-            validator
-            ^:mutable watches
-            ^:mutable watchesArr]
-     :cljs [^:mutable state
-            meta
-            validator
-            ^:mutable watches
-            ^:mutable watchesArr])
+  [^:mutable state
+   meta
+   validator
+   ^:mutable watches
+   ^:mutable watchesArr]
   #?(:cljs IAtom)
   IReactiveAtom
 
@@ -401,9 +396,8 @@
   (getArgs [])))
 
 (deftype Track
-  #?(:clj  [^:mutable f args
-            ^:mutable reaction]
-     :cljs [f args ^:mutable reaction])
+  [^:mutable f args ; Note: `f` is not marked mutable in Reagent but is nonetheless mutable
+   ^:mutable reaction]
   IReactiveAtom
 
   IDeref
@@ -460,14 +454,10 @@
   (getRatom [])))
 
 (deftype RCursor
-  #?(:clj  [ratom path
-            ^:mutable reaction
-            ^:mutable state
-            ^:mutable watches]
-     :cljs [ratom path
-            ^:mutable reaction
-            ^:mutable state
-            ^:mutable watches])
+  [ratom path
+   ^:mutable reaction
+   ^:mutable state
+   ^:mutable watches]
   #?(:cljs IAtom)
   IReactiveAtom
 
@@ -566,34 +556,23 @@
 (declare handle-reaction-change)
 
 (deftype Reaction
-  #?(:clj  [^:mutable f
-            ^:mutable state
-            ^:mutable dirty?
-            ^:mutable no-cache?
-            ^:mutable watching
-            ^:mutable watches
-            ^:mutable autoRun
-            ^:mutable caught
-            ^:mutable on-set
-            ^:mutable on-dispose
-            ^:mutable on-dispose-arr
-            ^:mutable captured
-            ^:mutable ratomGeneration
-            ^:mutable watchesArr]
-     :cljs [f ^:mutable state
-            ^:mutable
-            ^boolean dirty?
-            ^boolean no-cache?
-            ^:mutable watching
-            ^:mutable watches
-            ^:mutable autoRun
-            ^:mutable caught
-            ^:mutable on-set
-            ^:mutable on-dispose
-            ^:mutable on-dispose-arr
-            ^:mutable captured
-            ^:mutable ratomGeneration
-            ^:mutable watchesArr])
+  ; Note: `f`, `dirty?`, and `no-cache?` are not marked mutable in Reagent but are nonetheless mutable
+  [^:mutable f
+   ^:mutable state
+   #?(:clj ^:mutable dirty?
+      :cljs ^:mutable ^boolean dirty?)
+   #?(:clj ^:mutable no-cache?
+      :cljs ^:mutable ^boolean no-cache?)
+   ^:mutable watching
+   ^:mutable watches
+   ^:mutable autoRun
+   ^:mutable caught
+   ^:mutable on-set
+   ^:mutable on-dispose
+   ^:mutable on-dispose-arr
+   ^:mutable captured
+   ^:mutable ratomGeneration
+   ^:mutable watchesArr]
   #?(:cljs IAtom)
   IReactiveAtom
 
@@ -920,8 +899,7 @@
   nil))
 
 #?(:clj
-(defmacro reaction [& body]
-  `(make-reaction (fn [] ~@body))))
+(defmacro reaction [& body] `(make-reaction (fn [] ~@body))))
 
 #?(:clj
 (defmacro run!

--- a/src/posh/lib/ratom.cljc
+++ b/src/posh/lib/ratom.cljc
@@ -14,8 +14,8 @@
 ; the clojure.core/atom version takes ~345.78108 ms
 
 ; If you want to use mutability here, you need to make sure all transacts (really, listener updates)
-; and all derefs are on the same thread. Changing the appropriate macros is pretty easy — much more
-; so than changing all the places where the macro affects.
+; and all derefs are on the same thread. Changing the appropriate macros from atomic to mutable (or
+; vice versa) is pretty easy — much more so than changing all the places where the macro affects.
 
 ;;; Misc utils
 

--- a/src/posh/lib/util.cljc
+++ b/src/posh/lib/util.cljc
@@ -55,3 +55,21 @@
    Puts each x in `xs` as vals in a map.
    The keys in the map are the quoted vals. Then prints the map."
   [& xs] `(debug nil ~(->> xs (map #(vector (list 'quote %) %)) (into {})))))
+
+(defn dissoc-in
+  "Dissociate a value in a nested assocative structure, identified by a sequence
+   of keys. Any collections left empty by the operation will be dissociated from
+   their containing structures.
+   This implementation was adapted from clojure.core.contrib."
+  {:attribution "weavejester.medley"
+   :usage       `{(dissoc-in {:a {:b 1 :c 2} :d 3} [:a :b])
+                  {:a {:c 2} :d 3}}}
+  [m ks]
+  (if-let [[k & ks] (seq ks)]
+    (if (empty? ks)
+        (dissoc m k)
+        (let [new-n (dissoc-in (get m k) ks)]
+          (if (empty? new-n)
+              (dissoc m k)
+              (assoc m k new-n))))
+    m))

--- a/src/posh/lib/util.cljc
+++ b/src/posh/lib/util.cljc
@@ -33,7 +33,7 @@
 
 ;;; LOGGING ;;;
 
-(defonce debug? (atom true))
+(defonce debug? (atom false))
 
 #?(:clj
 (defmacro debug [msg & args]

--- a/src/posh/lib/util.cljc
+++ b/src/posh/lib/util.cljc
@@ -39,7 +39,7 @@
 
 (defn debug* [msg args]
   (#?@(:clj  [locking print-lock]
-       :cljs [identity])
+       :cljs [do])
     (println #?(:clj (java.util.Date.) :cljs (js/Date.))
       #?(:clj (str "[" (.getName (Thread/currentThread)) "]") :cljs nil)
       msg)

--- a/src/posh/lib/util.cljc
+++ b/src/posh/lib/util.cljc
@@ -56,6 +56,8 @@
    The keys in the map are the quoted vals. Then prints the map."
   [& xs] `(debug nil ~(->> xs (map #(vector (list 'quote %) %)) (into {})))))
 
+;;; COLLECTIONS ;;;
+
 (defn dissoc-in
   "Dissociate a value in a nested assocative structure, identified by a sequence
    of keys. Any collections left empty by the operation will be dissociated from
@@ -73,3 +75,23 @@
               (dissoc m k)
               (assoc m k new-n))))
     m))
+
+(defn merge-deep-with
+  "Like `merge-with` but merges maps recursively, applying the given fn
+  only when there's a non-map at a particular level."
+  {:attribution "clojure.contrib.map-utils via taoensso.encore"
+   :usage       `{(merge-deep-with + {:a {:b {:c 1 :d {:x 1 :y 2}     } :e 3  } :f 4}
+                                     {:a {:b {:c 2 :d {:z 9     } :z 3} :e 100}})
+                  {:a {:b {:z 3 :c 3 :d {:z 9 :x 1 :y 2}} :e 103} :f 4}}}
+  [f & maps]
+  (apply
+    (fn m [& maps]
+      (if (every? map? maps)
+          (apply merge-with m maps)
+          (apply f maps)))
+    maps))
+
+(def merge-deep
+  (partial merge-deep-with
+    (fn ([x]   (second x))
+        ([x y] y))))

--- a/src/posh/lib/util.cljc
+++ b/src/posh/lib/util.cljc
@@ -15,3 +15,27 @@
           [?e ?a _ ?t]]
         db
         datoms))
+
+(defonce debug? (atom true))
+
+#?(:clj
+(defmacro debug [msg & args]
+  (when @debug?
+    `(let [out-str# (with-out-str
+                      (println ~msg)
+                      ~@(for [arg args]
+                          `(clojure.pprint/pprint ~arg)))]
+       (print out-str#)
+       (flush)))))
+
+#?(:clj
+(defmacro prl
+  "'Print labeled'.
+   Puts each x in `xs` as vals in a map.
+   The keys in the map are the quoted vals. Then prints the map."
+  [& xs]
+  (when @debug?
+    `(let [out-str# (with-out-str
+                      (clojure.pprint/pprint ~(->> xs (map #(vector (list 'quote %) %)) (into {}))))]
+       (print out-str#)
+       (flush)))))

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -21,20 +21,23 @@
     (nil? id)
     (missing-pull-result query)))
 
+(defn- assert-listeners [conn]
+  (assert (->> conn meta :listeners (#?(:clj instance? :cljs satisfies?) #?(:clj clojure.lang.IAtom :cljs cljs.core/IAtom)))
+          (str "Connection requires listener metadata atom.")))
+
 ;; need to set last-tx-t in conn so that it doesn't try the same tx twice
 (defn set-conn-listener! [dcfg posh-atom conn db-id]
   (let [posh-vars {:posh-atom posh-atom
-                   :db-id db-id}]
+                   :db-id     db-id}
+        #_conn    #_(vary-meta conn update :listeners #(if (nil? %) (atom nil) %))
+        conn      ((or (:->poshable-conn dcfg) identity) conn)]
+    (assert-listeners conn)
     (do
       ((:listen! dcfg) conn :posh-dispenser
         (fn [var]
           (when (keyword? var)
             (get posh-vars var))))
-      (add-watch conn :posh-schema-listener
-        (fn [_ _ old-state new-state]
-          (when (not= (:schema old-state) (:schema new-state))
-            (swap! posh-atom assoc-in [:schema db-id] (:schema new-state)))))
-            ;; Update posh conn
+      ;; Update posh conn
       ((:listen! dcfg) conn :posh-listener
         (fn [tx-report]
           ;;(println "CHANGED: " (keys (:changed (p/after-transact @posh-atom {conn tx-report}))))
@@ -42,8 +45,11 @@
                 (swap! posh-atom p/after-transact {conn tx-report})]
             (doseq [[k v] changed]
               (reset! (get ratoms k) (:results v))))))
+      (when-let [f (:additional-listeners dcfg)] (f conn posh-atom db-id))
       conn)))
 
+; TODO allow for `unposh!` or some such thing
+; TODO warn if calling `posh!` multiple times on same conn
 (defn posh! [dcfg & conns]
   (let [posh-atom (atom {})]
     (reset! posh-atom
@@ -60,8 +66,7 @@
                          (p/add-db posh-tree
                                    db-id
                                    (set-conn-listener! dcfg posh-atom (first conns) db-id)
-                                   (:schema @(first conns))))))))))
-
+                                   (when-let [f (:conn->schema dcfg)] (f (first conns)))))))))))
 
 ;; Posh's state atoms are stored inside a listener in the meta data of
 ;; the datascript conn
@@ -185,7 +190,7 @@
                            (= (inc n-query-args) (count args))
                            [(butlast args) (last args)]
                            :else
-                           (throw "Incorrect number of args passed to posh query"))
+                           (throw (#?(:clj Exception. :cljs js/Error.) "Incorrect number of args passed to posh query")))
         true-poshdb-args (map #(if ((:conn? dcfg) %) (get-db dcfg %) %) args)
         posh-atom        (first (remove nil? (map #(get-posh-atom dcfg %) args)))
         storage-key      [:q query true-poshdb-args]]

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -47,7 +47,7 @@
           (let [{:keys [ratoms changed]}
                 (swap! posh-atom p/after-transact {conn tx-report})]
             (doseq [[k v] changed]
-              (reset! (get ratoms k) (:results v))))))
+              (when-let [r (get ratoms k)] (reset! r (:results v)))))))
       (when-let [f (:additional-listeners dcfg)] (f conn posh-atom db-id))
       conn)))
 

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -69,9 +69,10 @@
                          (p/add-db posh-tree
                                    db-id
                                    (set-conn-listener! dcfg posh-atom (first conns) db-id)
-                                   (when-let [f (:conn->schema dcfg)] (f (first conns)))))))))))
+                                   (when-let [f (:conn->schema dcfg)] (f (first conns)))))))))
+    posh-atom))
 
-(defn posh! [dcfg & conns] (posh!* dcfg conns [:results]))
+(defn posh! [dcfg & conns] @(posh!* dcfg conns [:results]))
 
 (defn posh-one!
   ([dcfg conn] (posh-one! dcfg conn [:results]))

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -36,13 +36,13 @@
     (do
       ((:listen! dcfg) conn :posh-dispenser
         (fn [var]
-          (debug "posh-dispenser" var)
+          #_(debug "posh-dispenser" var)
           (when (keyword? var)
             (get posh-vars var))))
       ;; Update posh conn
       ((:listen! dcfg) conn :posh-listener
         (fn [tx-report]
-          (debug "posh-listener" tx-report)
+          #_(debug "posh-listener" tx-report)
           ;;(println "CHANGED: " (keys (:changed (p/after-transact @posh-atom {conn tx-report}))))
           (let [{:keys [ratoms changed]}
                 (swap! posh-atom p/after-transact {conn tx-report})]

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -53,12 +53,12 @@
 
 ; TODO allow for `unposh!` or some such thing
 ; TODO warn if calling `posh!` multiple times on same conn
-(defn posh! [dcfg & conns]
+(defn posh!* [dcfg conns retrieve]
   (let [posh-atom (atom {})]
     (reset! posh-atom
             (loop [n 0
                    conns conns
-                   posh-tree (-> (p/empty-tree dcfg [:results])
+                   posh-tree (-> (p/empty-tree dcfg retrieve)
                                  (assoc :ratoms {}
                                         :reactions {}))]
               (if (empty? conns)
@@ -70,6 +70,12 @@
                                    db-id
                                    (set-conn-listener! dcfg posh-atom (first conns) db-id)
                                    (when-let [f (:conn->schema dcfg)] (f (first conns)))))))))))
+
+(defn posh! [dcfg & conns] (posh!* dcfg conns [:results]))
+
+(defn posh-one!
+  ([dcfg conn] (posh-one! dcfg conn [:results]))
+  ([dcfg conn retrieve] (posh!* dcfg [conn] retrieve)))
 
 ;; Posh's state atoms are stored inside a listener in the meta data of
 ;; the datascript conn
@@ -242,6 +248,7 @@
        (def ~'safe-pull           (partial posh.plugin-base/safe-pull           ~dcfg))
        (def ~'set-conn-listener!  (partial posh.plugin-base/set-conn-listener!  ~dcfg))
        (def ~'posh!               (partial posh.plugin-base/posh!               ~dcfg))
+       (def ~'posh-one!           (partial posh.plugin-base/posh-one!           ~dcfg))
        (def ~'get-conn-var        (partial posh.plugin-base/get-conn-var        ~dcfg))
        (def ~'get-posh-atom       (partial posh.plugin-base/get-posh-atom       ~dcfg))
        (def ~'get-db              (partial posh.plugin-base/get-db              ~dcfg))

--- a/src/posh/reagent.cljs
+++ b/src/posh/reagent.cljs
@@ -2,9 +2,10 @@
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [posh.plugin-base :as base
               :include-macros]
-            [datascript.core :as d]
-            [reagent.core :as r]
-            [reagent.ratom :as ra]))
+            [posh.lib.datascript :as ldb]
+            [datascript.core     :as d]
+            [reagent.core        :as r]
+            [reagent.ratom       :as ra]))
 
 (def dcfg
   (let [dcfg {:db            d/db
@@ -17,7 +18,9 @@
               :listen!       d/listen!
               :conn?         d/conn?
               :ratom         r/atom
-              :make-reaction ra/make-reaction}]
+              :make-reaction ra/make-reaction
+              :conn->schema  ldb/conn->schema
+              :additional-listeners ldb/add-schema-listener!}]
    (assoc dcfg :pull (partial base/safe-pull dcfg))))
 
 (base/add-plugin dcfg)

--- a/src/posh/stateful.cljc
+++ b/src/posh/stateful.cljc
@@ -12,10 +12,12 @@
 (defn new-posh [dcfg retrieve]
   (atom (p/empty-tree dcfg retrieve)))
 
-(defn add-db [posh-atom db-id conn schema opts]
-  (with-meta
-    (:return (reset! posh-atom (p/add-db @posh-atom db-id conn schema opts)))
-    {:posh posh-atom}))
+(defn add-db
+  ([posh-atom db-id conn schema] (add-db posh-atom db-id conn schema nil))
+  ([posh-atom db-id conn schema opts]
+    (with-meta
+      (:return (reset! posh-atom (p/add-db @posh-atom db-id conn schema opts)))
+      {:posh posh-atom})))
 
 ;;;;;;;;; adding queries  ;;;;;;;;;;
 

--- a/src/posh/sync.cljc
+++ b/src/posh/sync.cljc
@@ -1,0 +1,2 @@
+(ns posh.sync)
+

--- a/src/posh/sync/schema.cljc
+++ b/src/posh/sync/schema.cljc
@@ -82,7 +82,7 @@
 
 (defn update-schemas! [conn f]
   (assert (ds/conn? conn))
- (swap! conn update-schemas f))
+  (swap! conn update-schemas f))
 
 (defn merge-schemas
   "Immutably merges schemas and/or schema attributes (`schemas`) into the database `db`."

--- a/src/posh/sync/schema.cljc
+++ b/src/posh/sync/schema.cljc
@@ -1,0 +1,116 @@
+(ns posh.sync.schema
+  "Schema syncing and schema alteration functions."
+  (:require [clojure.set     :as set]
+            [datascript.core :as ds]
+    #?(:clj [datomic.api     :as dat])
+            [posh.lib.util :refer [dissoc-in merge-deep]]))
+
+(defn ensure-schema-changes-valid
+  "For DataScript db.
+   Will not change any user data as a result of schema alteration.
+   Assumes EAVT-indexed datoms."
+  {:attribution "alexandergunnarson"
+   :see-also    #{"https://github.com/tonsky/datascript/issues/174"}
+   :performance "At least O(d•s), where d = # datoms and s = # schemas to be changed"
+   :todo {0 "[:index true] -> [:index false] needs to take effect"
+          1 ":many -> :one needs to be validated but allowed"
+          2 "non-unique -> unique needs to be validated but allowed"
+          3 "use proper logging, not `println`"
+          4 "handle db/isComponent changes (necessary?)"}}
+  [schemas schemas' datoms]
+  (let [deleted       (set/difference (-> schemas keys set) (-> schemas' keys set))
+        changed+added (->> schemas' (remove (fn [[k v]] (= (get schemas k) v))))
+        illegal-schema-change
+          (fn [k v v'] (throw (ex-info "Illegal schema change attempted" {:k k :v v :v' v'})))
+        unclear-validation
+          (fn [k v v'] (println "WARN:" "Unclear whether DataScript will validate" k v "->" v'))] ; TODO 3
+    ; Ensure that no datoms are affected by deleted schemas
+    (doseq [[schema-name schema] deleted]
+      (doseq [[_ a _ _] datoms]
+        (assert (not= a schema-name))))
+    ; Ensure changed and added schemas are valid
+    (doseq [[schema-name' schema'] changed+added]
+      (let [schema (get schemas schema-name')]
+        (doseq [[k v'] schema']
+          (let [v (get schema k)]
+            (case k
+              :db/cardinality
+              (when (= [v v'] [:db.cardinality/many :db.cardinality/one])
+                (illegal-schema-change k v v')) ; TODO 1
+              :db/index
+              (when (and (true? v) (not v'))
+                (println "WARN:" "Unindexing" k "won't take effect in previous datoms")) ; TODO 0, 3
+              :db/valueType
+              (cond (and schema (not= v v'))
+                    (illegal-schema-change k v v')
+                    (not schema)
+                    (unclear-validation k v v'))
+              :db/unique
+              (cond
+                (and (not v) v)
+                (illegal-schema-change k v v') ; TODO 2
+                (= [v v'] [:db.unique/value :db.unique/identity])
+                (unclear-validation k v v')
+                (= [v v'] [:db.unique/identity :db.unique/value])
+                (unclear-validation k v v'))
+              :db/isComponent
+              (throw (ex-info "TODO" {})) ; TODO 4
+              ; Doesn't validate other schema changes
+              )))))))
+
+(defn update-schemas
+  "Updates the schemas of a DataScript db."
+  {:attribution "alexandergunnarson"
+   :see-also #{"metasoarous/datsync.client"
+               "http://docs.datomic.com/schema.html#Schema-Alteration"
+               "https://github.com/tonsky/datascript/issues/174"}}
+  ([db f]
+    (assert (ds/db? db))
+    (let [schemas  (:schema db)
+          schemas' (f schemas)
+          datoms   (ds/datoms db :eavt)]
+      (ensure-schema-changes-valid schemas schemas' datoms)
+      (-> (ds/init-db datoms schemas')
+          (ds/db-with
+            [{:db/ident  :type  }
+             {:db/ident  :schema}])
+          (ds/db-with
+            (for [schema (keys schemas')]
+              {:db/ident schema
+               :type     [:db/ident :schema]}))))))
+
+(defn update-schemas!
+  ([conn f]
+    (assert (ds/conn? conn))
+    (swap! conn update-schemas f)))
+
+(defn merge-schemas
+  "Immutably merges schemas and/or schema attributes (`schemas`) into the database `db`."
+  {:usage `(merge-schemas {:task:estimated-duration {:db/valueType :db.type/long}})}
+  ([#?(:clj _ :cljs db) schemas]
+  #?(:clj  (for [[schema kvs] schemas]
+             (merge
+               {:db/id               schema
+                :db.alter/_attribute :db.part/db}
+               kvs))
+     :cljs (update-schemas db #(merge-deep % schemas)))))
+
+(defn merge-schemas!
+  "Mutably merges (transacts) schemas and/or schema attributes (`schemas`) into the database `db`."
+  ([conn schemas]
+  #?(:clj  @(dat/transact conn (merge-schemas schemas)) ; TODO may want to sync schema?
+     :cljs (swap! conn merge-schemas schemas))))
+
+(defn replace-schemas!
+  "Mutably replaces schemas of the provided DataScript `conn`."
+  ([conn schemas]
+    (assert (ds/conn? conn))
+    (swap! conn update-schemas (constantly schemas))))
+
+(defn dissoc-schema!
+  "Mutably dissociates a schema from `conn`."
+  ([conn s k #?(:clj v :cljs _)]
+  #?(:clj  @(dat/transact conn ; TODO may want to sync schema?
+              [[:db/retract s k v]
+               [:db/add :db.part/db :db.alter/attribute k]])
+     :cljs (update-schemas! conn #(dissoc-in % [s k])))))

--- a/test/posh/clj/common_tests.clj
+++ b/test/posh/clj/common_tests.clj
@@ -1,0 +1,45 @@
+(ns posh.clj.common-tests
+  "Test fns shared between Datomic and DataScript (at very least in CLJ, but probably cross-platform)."
+  (:require [clojure.test        :as test
+              :refer [is deftest testing]]
+            [posh.lib.ratom      :as r]
+            [posh.lib.util       :as u
+              :refer [debug prl]]))
+
+(defn basic-test [conn dcfg]
+  (let [sub          ((:q dcfg) [:find '?e :where ['?e :test/attr]] conn)
+        sub-no-deref ((:q dcfg) [:find '?e :where ['?e :test/attr]] conn)
+        _ (is (= @sub #{}))
+        notified (atom 0)
+        _ (r/add-eager-watch sub :k (fn [_ _ _ _] (swap! notified inc)))
+        notified-no-deref (atom 0)
+        _ (r/add-eager-watch sub-no-deref :k-no-deref (fn [_ _ _ _] (swap! notified-no-deref inc)))]
+    (testing "Listeners are notified correctly"
+      ((:transact! dcfg) conn
+        [{:db/id     ((:tempid dcfg))
+          :test/attr "Abcde"}])
+      (do @sub @sub @sub @sub)
+      (is (= @sub
+             @((:q dcfg) [:find '?e
+                          :where ['?e :test/attr]]
+                         conn)
+             ((:q* dcfg) [:find '?e
+                          :where ['?e :test/attr]]
+                         ((:db dcfg) conn))))
+      (is (= @notified 1))
+      (is (= @notified-no-deref 1))
+      ((:transact! dcfg) conn
+        [{:db/id     ((:tempid dcfg))
+          :test/attr "Fghijk"}])
+      (do @sub @sub @sub @sub @sub)
+      (is (= @notified 2))
+      (is (= @notified-no-deref 2)))
+    (testing "Remove-watch happens correctly"
+      (remove-watch sub :k)
+      (remove-watch sub :k-no-deref)
+      ((:transact! dcfg) conn
+        [{:db/id     ((:tempid dcfg))
+          :test/attr "Lmnop"}])
+      (do @sub @sub @sub @sub @sub @sub)
+      (is (= @notified 2))
+      (is (= @notified-no-deref 2)))))

--- a/test/posh/clj/datascript_test.clj
+++ b/test/posh/clj/datascript_test.clj
@@ -1,13 +1,15 @@
 (ns posh.clj.datascript-test
-  (:require [clojure.test        :as test
+  (:require [clojure.test          :as test
               :refer [is deftest testing]]
-            [datascript.core     :as d]
-            [posh.clj.datascript :as db]
-            [posh.lib.ratom      :as r]
-            [posh.lib.util       :as u
-              :refer [debug prl]]))
+            [datascript.core       :as d]
+            [posh.clj.datascript   :as db]
+            [posh.lib.ratom        :as r]
+            [posh.lib.util         :as u
+              :refer [debug prl]]
+            [posh.clj.common-tests :as common]))
 
 (def default-partition :db.part/default)
+
 (defn tempid [] (d/tempid default-partition))
 
 (deftest basic-test
@@ -15,20 +17,9 @@
                               {;:db/valueType   :db.type/string
                                :db/cardinality :db.cardinality/one}})
         _    (db/posh! conn)]
-    (try (let [sub (db/q [:find '?e
-                          :where ['?e :test/attr]]
-                         conn)
-               _ (is (= @sub #{}))
-               notified-times (atom 0)
-               _ (r/run! @sub (swap! notified-times inc))
-               txn-report (db/transact! conn
-                            [{:db/id      (tempid)
-                              :test/attr  "Abcde"}])
-               _ (is (= @sub
-                        @(db/q [:find '?e
-                                :where ['?e :test/attr]]
-                               conn)
-                        (d/q [:find '?e
-                              :where ['?e :test/attr]]
-                              (d/db conn))))
-               _ (is (= @notified-times 2))]))))
+    (common/basic-test conn
+      {:q         db/q
+       :q*        d/q
+       :db        d/db
+       :tempid    tempid
+       :transact! db/transact!})))

--- a/test/posh/clj/datascript_test.clj
+++ b/test/posh/clj/datascript_test.clj
@@ -18,7 +18,7 @@
     (try (let [sub (db/q [:find '?e
                           :where ['?e :test/attr]]
                          conn)
-               _ (prl @sub)
+               _ (is (= @sub #{}))
                txn-report (db/transact! conn
                             [{:db/id      (tempid)
                               :test/attr  "Abcde"}])

--- a/test/posh/clj/datascript_test.clj
+++ b/test/posh/clj/datascript_test.clj
@@ -1,0 +1,31 @@
+(ns posh.clj.datascript-test
+  (:require [clojure.test        :as test
+              :refer [is deftest testing]]
+            [datascript.core     :as d]
+            [posh.clj.datascript :as db]
+            [posh.lib.ratom      :as r]
+            [posh.lib.util       :as u
+              :refer [debug prl]]))
+
+(def default-partition :db.part/default)
+(defn tempid [] (d/tempid default-partition))
+
+(deftest basic-test
+  (let [conn (d/create-conn {:test/attr
+                              {;:db/valueType   :db.type/string
+                               :db/cardinality :db.cardinality/one}})
+        _    (db/posh! conn)]
+    (try (let [sub (db/q [:find '?e
+                          :where ['?e :test/attr]]
+                         conn)
+               _ (prl @sub)
+               txn-report (db/transact! conn
+                            [{:db/id      (tempid)
+                              :test/attr  "Abcde"}])
+               _ (is (= @sub
+                        @(db/q [:find '?e
+                                :where ['?e :test/attr]]
+                               conn)
+                        (d/q [:find '?e
+                              :where ['?e :test/attr]]
+                              (d/db conn))))]))))

--- a/test/posh/clj/datascript_test.clj
+++ b/test/posh/clj/datascript_test.clj
@@ -3,6 +3,7 @@
               :refer [is deftest testing]]
             [datascript.core       :as d]
             [posh.clj.datascript   :as db]
+            [posh.lib.datascript   :as l]
             [posh.lib.ratom        :as r]
             [posh.lib.util         :as u
               :refer [debug prl]]
@@ -13,9 +14,9 @@
 (defn tempid [] (d/tempid default-partition))
 
 (deftest basic-test
-  (let [conn (d/create-conn {:test/attr
-                              {;:db/valueType   :db.type/string
-                               :db/cardinality :db.cardinality/one}})
+  (let [conn (d/create-conn (l/->schema {:test/attr
+                                          {:db/valueType   :db.type/string
+                                           :db/cardinality :db.cardinality/one}}))
         _    (db/posh! conn)]
     (common/basic-test conn
       {:q         db/q

--- a/test/posh/clj/datascript_test.clj
+++ b/test/posh/clj/datascript_test.clj
@@ -19,6 +19,8 @@
                           :where ['?e :test/attr]]
                          conn)
                _ (is (= @sub #{}))
+               notified-times (atom 0)
+               _ (r/run! @sub (swap! notified-times inc))
                txn-report (db/transact! conn
                             [{:db/id      (tempid)
                               :test/attr  "Abcde"}])
@@ -28,4 +30,5 @@
                                conn)
                         (d/q [:find '?e
                               :where ['?e :test/attr]]
-                              (d/db conn))))]))))
+                              (d/db conn))))
+               _ (is (= @notified-times 2))]))))

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -1,66 +1,16 @@
 (ns posh.clj.datomic-test
-  (:require [clojure.test          :as test
+  (:require [clojure.test     :as test
               :refer [is deftest testing]]
-            [datomic.api           :as d]
-            [posh.clj.datomic      :as db]
-            [posh.lib.ratom        :as r]
-            [posh.lib.util         :as u
+            [datomic.api      :as d]
+            [posh.clj.datomic :as db]
+            [posh.lib.datomic :as ldb]
+            [posh.lib.ratom   :as r]
+            [posh.lib.util    :as u
               :refer [debug prl]]
-            [posh.clj.common-tests :as common])
-  (:import posh.clj.datomic.PoshableConnection))
-
-#_(do (require '[clojure.tools.namespace.repl :refer [refresh]])
-      (reset! posh.lib.util/debug? true)
-      (refresh)
-      (set! *warn-on-reflection* true)
-      (eval `(do (clojure.test/run-tests 'posh.lib.ratom-test)
-                 (clojure.test/run-tests 'posh.clj.datascript-test)
-                 (clojure.test/run-tests 'posh.clj.datomic-test))))
-
-(def default-partition :db.part/default)
-
-(defn tempid [] (d/tempid default-partition))
-
-(defn install-partition [part]
-  (let [id (d/tempid :db.part/db)]
-    [{:db/id    id
-      :db/ident part}
-     [:db/add               :db.part/db
-      :db.install/partition id]]))
-
-(defmacro with-conn [sym & body]
-  `(let [uri# "datomic:mem://test"]
-     (try (d/create-database uri#)
-          (let [~sym (d/connect uri#)]
-            (try ~@body
-              (finally (d/release ~sym))))
-          (finally (d/delete-database uri#)))))
-
-(defn transact-schemas!
-  "This is used because, perhaps very strangely, schema changes to Datomic happen
-   asynchronously."
-  [conn schemas]
-  (let [txn-report (db/transact! conn
-                     (->> schemas
-                          (map #(assoc % :db/id (d/tempid :db.part/db)
-                                         :db.install/_attribute :db.part/db))))
-        txn-id     (-> txn-report :tx-data first (get 3))
-        _ #_(deref (d/sync (db/->conn conn) (java.util.Date. (System/currentTimeMillis))) 500 nil)
-            (deref (d/sync-schema (db/->conn conn) (inc txn-id)) 500 nil)] ; frustratingly, doesn't even work with un-`inc`ed txn-id
-    txn-report))
-
-(defn with-setup [schemas f]
-  (with-conn conn*
-    (let [poshed (db/posh! conn*) ; This performs a `with-meta` so the result is needed
-          conn   (-> poshed :conns :conn0) ; Has the necessary meta ; TODO simplify this
-          _      (is (instance? PoshableConnection conn))]
-      (try (let [txn-report (db/transact! conn (install-partition default-partition))
-                 txn-report (transact-schemas! conn schemas)]
-             (f conn))
-        (finally (db/stop conn)))))) ; TODO `unposh!`
+            [posh.clj.common-tests :as common]))
 
 (deftest basic-test
-  (with-setup
+  (ldb/with-posh-conn "datomic:mem://test"
     [{:db/ident       :test/attr
       :db/valueType   :db.type/string
       :db/cardinality :db.cardinality/one}]
@@ -69,5 +19,5 @@
         {:db        db/db*
          :q         db/q
          :q*        d/q
-         :tempid    tempid
+         :tempid    ldb/tempid
          :transact! db/transact!}))))

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -59,7 +59,7 @@
                  sub (db/q [:find '?e
                             :where ['?e :test/attr]]
                            conn)
-                 _ (prl @sub)
+                 _ (is (= @sub #{}))
                  txn-report (db/transact! conn
                               [{:db/id (tempid)
                                 :test/attr  "Abcde"}])

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -69,23 +69,33 @@
             notified (atom 0)
             _ (r/add-eager-watch sub :k (fn [_ _ _ _] (swap! notified inc)))
             notified-no-deref (atom 0)
-            _ (r/add-eager-watch sub-no-deref :k-no-deref (fn [_ _ _ _] (swap! notified-no-deref inc)))
-            txn-report (db/transact! conn
-                         [{:db/id     (tempid)
-                           :test/attr "Abcde"}])
-            _ (do @sub @sub @sub @sub)
-            _ (is (= @sub
-                     @(db/q [:find '?e
-                             :where ['?e :test/attr]]
-                            conn)
-                     (d/q [:find '?e
-                           :where ['?e :test/attr]]
-                           (db/db* conn))))
-            _ (is (= @notified 1))
-            _ (is (= @notified-no-deref 1))
-            txn-report (db/transact! conn
-                         [{:db/id     (tempid)
-                           :test/attr "Fghijk"}])
-            _ (do @sub @sub @sub @sub @sub)
-            _ (is (= @notified 2))
-            _ (is (= @notified-no-deref 2))]))))
+            _ (r/add-eager-watch sub-no-deref :k-no-deref (fn [_ _ _ _] (swap! notified-no-deref inc)))]
+      (testing "Listeners are notified correctly"
+        (db/transact! conn
+          [{:db/id     (tempid)
+            :test/attr "Abcde"}])
+        (do @sub @sub @sub @sub)
+        (is (= @sub
+               @(db/q [:find '?e
+                       :where ['?e :test/attr]]
+                      conn)
+               (d/q [:find '?e
+                     :where ['?e :test/attr]]
+                     (db/db* conn))))
+        (is (= @notified 1))
+        (is (= @notified-no-deref 1))
+        (db/transact! conn
+          [{:db/id     (tempid)
+            :test/attr "Fghijk"}])
+        (do @sub @sub @sub @sub @sub)
+        (is (= @notified 2))
+        (is (= @notified-no-deref 2)))
+      (testing "Remove-watch happens correctly"
+        (remove-watch sub :k)
+        (remove-watch sub :k-no-deref)
+        (db/transact! conn
+          [{:db/id     (tempid)
+            :test/attr "Lmnop"}])
+        (do @sub @sub @sub @sub @sub @sub)
+        (is (= @notified 2))
+        (is (= @notified-no-deref 2)))))))

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -64,11 +64,11 @@
                  txn-report (db/transact! conn
                               [{:db/id (tempid)
                                 :test/attr  "Abcde"}])
-                 _ (prl @sub
-                        @(db/q [:find '?e
+                 _ (is (= @sub
+                          @(db/q [:find '?e
+                                  :where ['?e :test/attr]]
+                                 conn)
+                          (d/q [:find '?e
                                 :where ['?e :test/attr]]
-                               conn)
-                        (d/q [:find '?e
-                              :where ['?e :test/attr]]
-                              (db/db* conn)))])
+                                (db/db* conn))))])
            (finally (db/stop conn)))))) ; TODO `unposh!`

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -60,14 +60,18 @@
                             :where ['?e :test/attr]]
                            conn)
                  _ (is (= @sub #{}))
+                 notified-times (atom 0)
+                 _ (r/run! @sub (swap! notified-times inc))
                  txn-report (db/transact! conn
-                              [{:db/id (tempid)
-                                :test/attr  "Abcde"}])
+                              [{:db/id     (tempid)
+                                :test/attr "Abcde"}])
+                 _ (Thread/sleep 1000)
                  _ (is (= @sub
                           @(db/q [:find '?e
                                   :where ['?e :test/attr]]
                                  conn)
                           (d/q [:find '?e
                                 :where ['?e :test/attr]]
-                                (db/db* conn))))])
+                                (db/db* conn))))
+                 _ (is (= @notified-times 2))])
            (finally (db/stop conn)))))) ; TODO `unposh!`

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -15,8 +15,7 @@
      (load-file "./test/posh/clj/datomic_test.clj")
      (eval '(clojure.test/run-tests 'posh.clj.datomic-test)))
 
-(def ^{:doc "The default partition"} default-partition :db.part/default)
-
+(def default-partition :db.part/default)
 (defn tempid [] (d/tempid default-partition))
 
 (defn install-partition [part]

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -10,13 +10,12 @@
             [posh.clj.common-tests :as common]))
 
 (deftest basic-test
-  (ldb/with-posh-conn [:results] "datomic:mem://test"
-    [{:db/ident       :test/attr
-      :db/valueType   :db.type/string
-      :db/cardinality :db.cardinality/one}]
-    (fn [conn]
+  (ldb/with-posh-conn db/dcfg [:results] "datomic:mem://test"
+    {:test/attr {:db/valueType   :db.type/string
+                 :db/cardinality :db.cardinality/one}}
+    (fn [poshed conn]
       (common/basic-test conn
-        {:db        db/db*
+        {:db        ldb/db*
          :q         db/q
          :q*        d/q
          :tempid    ldb/tempid

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -3,21 +3,21 @@
               :refer [is deftest testing]]
             [datomic.api      :as d]
             [posh.clj.datomic :as db]
-            [posh.lib.ratom   :as r])
+            [posh.lib.ratom   :as r]
+            [posh.lib.util :as u
+              :refer [debug prl]])
   (:import posh.clj.datomic.PoshableConnection))
 
-(defonce debug? (atom true))
-
-; TODO move
-(defmacro prl
-  "'Print labeled'.
-   Puts each x in `xs` as vals in a map.
-   The keys in the map are the quoted vals. Then prints the map."
-  [level & xs]
-  `(when @debug?
-     (clojure.pprint/pprint ~(->> xs (map #(vector (list 'quote %) %)) (into {})))))
+#_(do (set! *warn-on-reflection* true)
+    (reset! posh.lib.util/debug? true)
+    #_(load-file "./src/posh/plugin_base.cljc")
+    (load-file "./src/posh/clj/datomic.clj")
+     (load-file "./test/posh/clj/datomic_test.clj")
+     (eval '(clojure.test/run-tests 'posh.clj.datomic-test)))
 
 (def ^{:doc "The default partition"} default-partition :db.part/default)
+
+(defn tempid [] (d/tempid default-partition))
 
 (defn install-partition [part]
   (let [id (d/tempid :db.part/db)]
@@ -34,20 +34,41 @@
               (finally (d/release ~sym))))
           (finally (d/delete-database uri#)))))
 
+(defn transact-schemas!
+  "This is used because, perhaps very strangely, schema changes to Datomic happen
+   asynchronously."
+  [conn schemas]
+  (let [txn-report (db/transact! conn
+                     (->> schemas
+                          (map #(assoc % :db/id (d/tempid :db.part/db)
+                                         :db.install/_attribute :db.part/db))))
+        txn-id     (-> txn-report :tx-data ^datomic.Datom first .tx)
+        _ #_(deref (d/sync (db/->conn conn) (java.util.Date. (System/currentTimeMillis))) 500 nil)
+            (deref (d/sync-schema (db/->conn conn) (inc txn-id)) 500 nil)] ; frustratingly, doesn't even work with un-`inc`ed txn-id
+    txn-report))
+
 (deftest basic-test
-  (with-conn conn
-    (let [poshed (db/posh! conn) ; This performs a `with-meta` so the result is needed
+  (with-conn conn*
+    (let [poshed (db/posh! conn*) ; This performs a `with-meta` so the result is needed
           conn   (-> poshed :conns :conn0) ; Has the necessary meta ; TODO simplify this
           _      (is (instance? PoshableConnection conn))]
       (try (let [txn-report (db/transact! conn (install-partition default-partition))
+                 txn-report (transact-schemas! conn
+                              [{:db/ident       :test/attr
+                                :db/valueType   :db.type/string
+                                :db/cardinality :db.cardinality/one}])
+                 sub (db/q [:find '?e
+                            :where ['?e :test/attr]]
+                           conn)
+                 _ (prl @sub)
                  txn-report (db/transact! conn
-                              [{:db/id                 (d/tempid :db.part/db)
-                                :db/ident              :attr
-                                :db/valueType          :db.type/string
-                                :db/cardinality        :db.cardinality/one
-                                :db.install/_attribute :db.part/db}])
-                 sub (db/q [:find '?e '?v
-                            :where ['?e :attr '?v]]
-                           conn)]
-             (prl @sub))
+                              [{:db/id (tempid)
+                                :test/attr  "Abcde"}])
+                 _ (prl @sub
+                        @(db/q [:find '?e
+                                :where ['?e :test/attr]]
+                               conn)
+                        (d/q [:find '?e
+                              :where ['?e :test/attr]]
+                              (db/db* conn)))])
            (finally (db/stop conn)))))) ; TODO `unposh!`

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -1,0 +1,53 @@
+(ns posh.clj.datomic-test
+  (:require [clojure.test     :as test
+              :refer [is deftest testing]]
+            [datomic.api      :as d]
+            [posh.clj.datomic :as db]
+            [posh.lib.ratom   :as r])
+  (:import posh.clj.datomic.PoshableConnection))
+
+(defonce debug? (atom true))
+
+; TODO move
+(defmacro prl
+  "'Print labeled'.
+   Puts each x in `xs` as vals in a map.
+   The keys in the map are the quoted vals. Then prints the map."
+  [level & xs]
+  `(when @debug?
+     (clojure.pprint/pprint ~(->> xs (map #(vector (list 'quote %) %)) (into {})))))
+
+(def ^{:doc "The default partition"} default-partition :db.part/default)
+
+(defn install-partition [part]
+  (let [id (d/tempid :db.part/db)]
+    [{:db/id    id
+      :db/ident part}
+     [:db/add               :db.part/db
+      :db.install/partition id]]))
+
+(defmacro with-conn [sym & body]
+  `(let [uri# "datomic:mem://test"]
+     (try (d/create-database uri#)
+          (let [~sym (d/connect uri#)]
+            (try ~@body
+              (finally (d/release ~sym))))
+          (finally (d/delete-database uri#)))))
+
+(deftest basic-test
+  (with-conn conn
+    (let [poshed (db/posh! conn) ; This performs a `with-meta` so the result is needed
+          conn   (-> poshed :conns :conn0) ; Has the necessary meta ; TODO simplify this
+          _      (is (instance? PoshableConnection conn))]
+      (try (let [txn-report (db/transact! conn (install-partition default-partition))
+                 txn-report (db/transact! conn
+                              [{:db/id                 (d/tempid :db.part/db)
+                                :db/ident              :attr
+                                :db/valueType          :db.type/string
+                                :db/cardinality        :db.cardinality/one
+                                :db.install/_attribute :db.part/db}])
+                 sub (db/q [:find '?e '?v
+                            :where ['?e :attr '?v]]
+                           conn)]
+             (prl @sub))
+           (finally (db/stop conn)))))) ; TODO `unposh!`

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -82,4 +82,10 @@
                            :where ['?e :test/attr]]
                            (db/db* conn))))
             _ (is (= @notified 1))
-            _ (is (= @notified-no-deref 1))]))))
+            _ (is (= @notified-no-deref 1))
+            txn-report (db/transact! conn
+                         [{:db/id     (tempid)
+                           :test/attr "Fghijk"}])
+            _ (do @sub @sub @sub @sub @sub)
+            _ (is (= @notified 2))
+            _ (is (= @notified-no-deref 2))]))))

--- a/test/posh/clj/datomic_test.clj
+++ b/test/posh/clj/datomic_test.clj
@@ -1,16 +1,16 @@
 (ns posh.clj.datomic-test
-  (:require [clojure.test     :as test
+  (:require [clojure.test          :as test
               :refer [is deftest testing]]
-            [datomic.api      :as d]
-            [posh.clj.datomic :as db]
-            [posh.lib.datomic :as ldb]
-            [posh.lib.ratom   :as r]
-            [posh.lib.util    :as u
+            [datomic.api           :as d]
+            [posh.clj.datomic      :as db]
+            [posh.lib.datomic      :as ldb]
+            [posh.lib.ratom        :as r]
+            [posh.lib.util         :as u
               :refer [debug prl]]
             [posh.clj.common-tests :as common]))
 
 (deftest basic-test
-  (ldb/with-posh-conn "datomic:mem://test"
+  (ldb/with-posh-conn [:results] "datomic:mem://test"
     [{:db/ident       :test/attr
       :db/valueType   :db.type/string
       :db/cardinality :db.cardinality/one}]

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -211,12 +211,14 @@
     (try (f chans)
       (finally (doseq [c (vals chans)] (close! c))))))
 
+; Retrieve users whose public information is visible
 (def user-public-q
   '[:find ?username ?name
     :where
       [?u :user/username      ?username]
       [?u :user/name          ?name]])
 
+; Retrieve users whose private information is visible
 (def user-private-q
   '[:find ?username ?name ?location
     :where
@@ -224,6 +226,7 @@
       [?u :user/name          ?name]
       [?u :user/location      ?location]])
 
+; Retrieve users whose admin information is visible
 (def user-admin-q
   '[:find ?username ?name ?location ?password-hash
     :where
@@ -232,7 +235,8 @@
       [?u :user/location      ?location]
       [?u :user/password-hash ?password-hash]])
 
-(def repo-q ; public/private depending on the db passed in
+; Retrieve all visible repos
+(def repo-q
   '[:find ?name ?r ?id ?content
     :where
       [?r :repo/name           ?name]
@@ -303,77 +307,72 @@
               (report-while-open! :mpdairy-client            mpc)
               (report-while-open! :alexandergunnarson-client mpc))
             (testing "DB initialization"
-              (let [mpdairy-public             #{[277076930200556 :user/username      :mpdairy                  13194139534315]
-                                                 [277076930200556 :user/name          "Matt Parker"             13194139534315]}
-                    mpdairy-private            #{[277076930200556 :user/location      :usa                      13194139534315]}
-                    mpdairy-admin              #{[277076930200556 :user/password-hash "mpdairy/hash"            13194139534315]}
-                    mpdairy                    (set/union mpdairy-public mpdairy-private mpdairy-admin)
-                    alexandergunnarson-public  #{[277076930200559 :user/username      :alexandergunnarson       13194139534315]
-                                                 [277076930200559 :user/name          "Alex Gunnarson"          13194139534315]}
-                    alexandergunnarson-private #{[277076930200559 :user/location      :utah                     13194139534315]}
-                    alexandergunnarson-admin   #{[277076930200559 :user/password-hash "alexandergunnarson/hash" 13194139534315]}
-                    alexandergunnarson         (set/union alexandergunnarson-public alexandergunnarson-private alexandergunnarson-admin)]
+              (let [mpdairy-public                  #{[277076930200556 :user/username       :mpdairy                         13194139534315]
+                                                      [277076930200556 :user/name           "Matt Parker"                    13194139534315]}
+                    mpdairy-private                 #{[277076930200556 :user/location       :usa                             13194139534315]}
+                    mpdairy-admin                   #{[277076930200556 :user/password-hash  "mpdairy/hash"                   13194139534315]}
+                    mpdairy                         (set/union mpdairy-public mpdairy-private mpdairy-admin)
+                    posh                            #{[277076930200557 :repo/name           :posh                            13194139534315]
+                                                      [277076930200563 :repo.commit/to      277076930200557                  13194139534322]
+                                                      [277076930200563 :repo.commit/id      :posh/_0                         13194139534322]
+                                                      [277076930200563 :repo.commit/content ":posh/_0"                       13194139534322]
+                                                      [277076930200564 :repo.commit/to      277076930200557                  13194139534322]
+                                                      [277076930200564 :repo.commit/id      :posh/_1                         13194139534322]
+                                                      [277076930200564 :repo.commit/content ":posh/_1"                       13194139534322]}
+                    mpdairy-private-repo            #{[277076930200558 :repo/name           :mpdairy-private                 13194139534315]
+                                                      [277076930200565 :repo.commit/to      277076930200558                  13194139534322]
+                                                      [277076930200565 :repo.commit/id      :mpdairy-private/_0              13194139534322]
+                                                      [277076930200565 :repo.commit/content ":mpdairy-private/_0"            13194139534322]
+                                                      [277076930200566 :repo.commit/to      277076930200558                  13194139534322]
+                                                      [277076930200566 :repo.commit/id      :mpdairy-private/_1              13194139534322]
+                                                      [277076930200566 :repo.commit/content ":mpdairy-private/_1"            13194139534322]}
+
+                    alexandergunnarson-public       #{[277076930200559 :user/username       :alexandergunnarson              13194139534315]
+                                                      [277076930200559 :user/name           "Alex Gunnarson"                 13194139534315]}
+                    alexandergunnarson-private      #{[277076930200559 :user/location       :utah                            13194139534315]}
+                    alexandergunnarson-admin        #{[277076930200559 :user/password-hash  "alexandergunnarson/hash"        13194139534315]}
+                    alexandergunnarson              (set/union alexandergunnarson-public alexandergunnarson-private alexandergunnarson-admin)
+                    quantum                         #{[277076930200560 :repo/name           :quantum                         13194139534315]
+                                                      [277076930200567 :repo.commit/id      :quantum/_0                      13194139534322]
+                                                      [277076930200567 :repo.commit/to      277076930200560                  13194139534322]
+                                                      [277076930200567 :repo.commit/content ":quantum/_0"                    13194139534322]
+                                                      [277076930200568 :repo.commit/id      :quantum/_1                      13194139534322]
+                                                      [277076930200568 :repo.commit/content ":quantum/_1"                    13194139534322]
+                                                      [277076930200568 :repo.commit/to      277076930200560                  13194139534322]}
+                    alexandergunnarson-private-repo #{[277076930200561 :repo/name           :alexandergunnarson-private      13194139534315]
+                                                      [277076930200569 :repo.commit/id      :alexandergunnarson-private/_0   13194139534322]
+                                                      [277076930200569 :repo.commit/to      277076930200561                  13194139534322]
+                                                      [277076930200569 :repo.commit/content ":alexandergunnarson-private/_0" 13194139534322]
+                                                      [277076930200570 :repo.commit/content ":alexandergunnarson-private/_1" 13194139534322]
+                                                      [277076930200570 :repo.commit/to      277076930200561                  13194139534322]
+                                                      [277076930200570 :repo.commit/id      :alexandergunnarson-private/_1   13194139534322]}]
+                (testing "user-public-q"
+                  (doseq [username #{:mpdairy :alexandergunnarson}]
+                    (testing username
+                      (is (= (get-in-cache dat-poshed username user-public-q)
+                             (set/union mpdairy-public alexandergunnarson-public))))))
+                (testing "user-private-q"
+                  (testing :mpdairy
+                    (is (= (get-in-cache dat-poshed :mpdairy user-private-q)
+                           (set/union mpdairy-public mpdairy-private))))
+                  (testing :alexandergunnarson
+                    (is (= (get-in-cache dat-poshed :alexandergunnarson user-private-q)
+                           (set/union alexandergunnarson-public alexandergunnarson-private)))))
                 (testing "user-admin-q"
-                  (testing "admin"
+                  (testing :admin
                     (is (= (get-in-cache dat-poshed :conn0 user-admin-q)
                            (set/union mpdairy alexandergunnarson))))
                   (doseq [username #{:mpdairy :alexandergunnarson}]
                     (testing username
                       (is (= (get-in-cache dat-poshed username user-admin-q)
                              nil)))))
-                (testing "user-public-q"
-                  (doseq [username #{:mpdairy :alexandergunnarson}]
-                    (testing username
-                      (is (= (get-in-cache dat-poshed username user-public-q)
-                             (set/union mpdairy-public alexandergunnarson-public))))))
                 (testing "repo-q"
                   (testing :mpdairy
                     (is (= (get-in-cache dat-poshed :mpdairy repo-q)
-                           #{[277076930200563 :repo.commit/to      277076930200557       13194139534322]
-                             [277076930200564 :repo.commit/id      :posh/_1              13194139534322]
-                             [277076930200560 :repo/name           :quantum              13194139534315]
-                             [277076930200564 :repo.commit/content ":posh/_1"            13194139534322]
-                             [277076930200565 :repo.commit/to      277076930200558       13194139534322]
-                             [277076930200563 :repo.commit/content ":posh/_0"            13194139534322]
-                             [277076930200557 :repo/name           :posh                 13194139534315]
-                             [277076930200563 :repo.commit/id      :posh/_0              13194139534322]
-                             [277076930200567 :repo.commit/id      :quantum/_0           13194139534322]
-                             [277076930200568 :repo.commit/id      :quantum/_1           13194139534322]
-                             [277076930200568 :repo.commit/content ":quantum/_1"         13194139534322]
-                             [277076930200566 :repo.commit/id      :mpdairy-private/_1   13194139534322]
-                             [277076930200558 :repo/name           :mpdairy-private      13194139534315]
-                             [277076930200565 :repo.commit/id      :mpdairy-private/_0   13194139534322]
-                             [277076930200566 :repo.commit/content ":mpdairy-private/_1" 13194139534322]
-                             [277076930200564 :repo.commit/to      277076930200557       13194139534322]
-                             [277076930200565 :repo.commit/content ":mpdairy-private/_0" 13194139534322]
-                             [277076930200566 :repo.commit/to      277076930200558       13194139534322]
-                             [277076930200567 :repo.commit/to      277076930200560       13194139534322]
-                             [277076930200567 :repo.commit/content ":quantum/_0"         13194139534322]
-                             [277076930200568 :repo.commit/to      277076930200560       13194139534322]})))
+                           (set/union posh mpdairy-private-repo quantum))))
                   (testing :alexandergunnarson
                     (is (= (get-in-cache dat-poshed :alexandergunnarson repo-q)
-                           #{[277076930200569 :repo.commit/id      :alexandergunnarson-private/_0   13194139534322]
-                             [277076930200563 :repo.commit/to      277076930200557                  13194139534322]
-                             [277076930200564 :repo.commit/id      :posh/_1                         13194139534322]
-                             [277076930200569 :repo.commit/to      277076930200561                  13194139534322]
-                             [277076930200569 :repo.commit/content ":alexandergunnarson-private/_0" 13194139534322]
-                             [277076930200560 :repo/name           :quantum                         13194139534315]
-                             [277076930200564 :repo.commit/content ":posh/_1"                       13194139534322]
-                             [277076930200570 :repo.commit/content ":alexandergunnarson-private/_1" 13194139534322]
-                             [277076930200563 :repo.commit/content ":posh/_0"                       13194139534322]
-                             [277076930200557 :repo/name           :posh                            13194139534315]
-                             [277076930200563 :repo.commit/id      :posh/_0                         13194139534322]
-                             [277076930200567 :repo.commit/id      :quantum/_0                      13194139534322]
-                             [277076930200570 :repo.commit/to      277076930200561                  13194139534322]
-                             [277076930200568 :repo.commit/id      :quantum/_1                      13194139534322]
-                             [277076930200570 :repo.commit/id      :alexandergunnarson-private/_1   13194139534322]
-                             [277076930200568 :repo.commit/content ":quantum/_1"                    13194139534322]
-                             [277076930200564 :repo.commit/to      277076930200557                  13194139534322]
-                             [277076930200561 :repo/name           :alexandergunnarson-private      13194139534315]
-                             [277076930200567 :repo.commit/to      277076930200560                  13194139534322]
-                             [277076930200567 :repo.commit/content ":quantum/_0"                    13194139534322]
-                             [277076930200568 :repo.commit/to      277076930200560                  13194139534322]}))))))
-
+                           (set/union quantum alexandergunnarson-private-repo posh)))))))
             #_(prl (query-cache dat-poshed))
             ; TODO try retracts as well
             (pdat/transact! dat [(->git-commit dcfg-dat :posh 2)])

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -23,41 +23,6 @@
              [cljs.core.async.macros
               :refer [go go-loop]])))
 
-(def schema
-  {:category/name         {:db/valueType   :db.type/string
-                           :db/cardinality :db.cardinality/one
-                           :db/unique      :db.unique/identity}
-   :category/todo         {:db/valueType   :db.type/ref
-                           :db/cardinality :db.cardinality/one}
-   :task/category         {:db/valueType   :db.type/ref
-                           :db/cardinality :db.cardinality/one}
-   :task/done             {:db/valueType   :db.type/boolean
-                           :db/cardinality :db.cardinality/one}
-   :task/name             {:db/valueType   :db.type/string
-                           :db/cardinality :db.cardinality/one
-                           :db/unique      :db.unique/identity}
-   :task/pinned           {:db/valueType   :db.type/boolean
-                           :db/cardinality :db.cardinality/one}
-   :todo/display-category {:db/valueType   :db.type/ref
-                           :db/cardinality :db.cardinality/one}
-   :todo/listing          {:db/valueType   :db.type/keyword
-                           :db/cardinality :db.cardinality/one}
-   :todo/name             {:db/valueType   :db.type/string
-                           :db/unique      :db.unique/identity
-                           :db/cardinality :db.cardinality/one}
-   :todo/numbers          {:db/valueType   :db.type/long
-                           :db/cardinality :db.cardinality/many}
-   :todo/owner            {:db/valueType   :db.type/ref
-                           :db/cardinality :db.cardinality/one}
-   :permission/level      {:db/valueType   :db.type/long
-                           :db/cardinality :db.cardinality/one}
-   :permission/uuid       {:db/valueType   :db.type/string
-                           :db/cardinality :db.cardinality/one}
-   :person/age            {:db/valueType   :db.type/long
-                           :db/cardinality :db.cardinality/one}
-   :person/name           {:db/valueType   :db.type/string
-                           :db/cardinality :db.cardinality/one}})
-
 (defn ->ident [db x]
   (cond (instance? datascript.db.DB db)
         x
@@ -65,72 +30,132 @@
                   (dat/ident db x)])
         :else (throw (ex-info "Unsupported db to look up ident" {:db db :ident x}))))
 
-(defn attribute= [db attr-0 attr-1]
+(defn ->e [datom]
+  (if (vector? datom)
+      (get datom 0)
+      (:e datom)))
+
+(defn ->a [datom]
+  (if (vector? datom)
+      (get datom 1)
+      (:a datom)))
+
+(defn ->v [datom]
+  (if (vector? datom)
+      (get datom 2)
+      (:v datom)))
+
+(defn ->t [datom]
+  (if (vector? datom)
+      (get datom 3)
+      (:t datom)))
+
+(defn ident= [db attr-0 attr-1]
   (let [attr-0 (->ident db attr-0)
         attr-1 (->ident db attr-1)]
     (= attr-0 attr-1)))
 
-(defn no-task-names-filter [db datom]
-  (let [attr (if #?(:clj  (instance? datomic.Datom datom)
-                    :cljs false)
-                 (:a datom)
-                 (second datom))]
-    (not (attribute= db attr :task/name))))
+; GitHub repositories schema
+(def schema
+  {:repo/name             {:db/valueType   :db.type/keyword
+                           :db/cardinality :db.cardinality/one
+                           :db/unique      :db.unique/identity} ; really, unique by :user/username, enforced via tx fn
+   :repo/owner            {:db/valueType   :db.type/ref
+                           :db/cardinality :db.cardinality/one}
+   :repo/private?         {:db/valueType   :db.type/boolean
+                           :db/cardinality :db.cardinality/one}
+   ; Commits are ordered by their ids
+   :repo.commit/to        {:db/valueType   :db.type/ref ; really, ref to :repo enforced via tx fn
+                           :db/cardinality :db.cardinality/one}
+   :repo.commit/id        {:db/valueType   :db.type/keyword
+                           :db/cardinality :db.cardinality/one
+                           :db/unique      :db.unique/identity} ; really, unique by :repo.commit/to, enforced via tx fn
+   :repo.commit/content   {:db/valueType   :db.type/string ; the text of the commit
+                           :db/cardinality :db.cardinality/one}
+   :user/username         {:db/valueType   :db.type/keyword
+                           :db/cardinality :db.cardinality/one
+                           :db/unique      :db.unique/identity}
+   :user/name             {:db/valueType   :db.type/string
+                           :db/cardinality :db.cardinality/one}
+   :user/location         {:db/valueType   :db.type/keyword
+                           :db/cardinality :db.cardinality/one}
+   :user/password-hash    {:db/valueType   :db.type/string
+                           :db/cardinality :db.cardinality/one}})
 
-(defn populate! [conn {:keys [tempid transact!] :as dcfg}]
-  (let [matt       {:db/id (tempid) :person/name "Matt" :person/age 14}
-        todos      {:db/id (tempid)
-                    :todo/name "Matt's List" :todo/listing :all
-                    :todo/owner (:db/id matt)}
-        at-home    {:db/id (tempid) :category/name "At Home"    :category/todo (:db/id todos)}
-        work-stuff {:db/id (tempid) :category/name "Work Stuff" :category/todo (:db/id todos)}
-        hobby      {:db/id (tempid) :category/name "Hobby"      :category/todo (:db/id todos)}]
-    (transact!
-     conn
-     [matt
-      todos
-      at-home
-      work-stuff
-      hobby
-      [:db/add (:db/id todos) :todo/numbers 12]
-      [:db/add (:db/id todos) :todo/numbers 20]
-      [:db/add (:db/id todos) :todo/numbers 443]
-      {:db/id (tempid)
-       :task/name "Clean Dishes"
-       :task/done true
-       :permission/uuid "uktdkafojea"
-       :task/category (:db/id at-home)}
-      {:db/id (tempid)
-       :task/name "Mop Floors"
-       :task/done true
-       :task/pinned true
-       :permission/uuid "sieojeiofja"
-       :task/category (:db/id at-home)}
-      {:db/id (tempid)
-       :task/name "Draw a picture of a cat"
-       :task/done false
-       :permission/uuid "sieojeiofja"
-       :task/category (:db/id hobby)}
-      {:db/id (tempid)
-       :task/name "Compose opera"
-       :task/done true
-       :permission/uuid "bmmsmsdlfds"
-       :task/category (:db/id hobby)}
-      {:db/id (tempid)
-       :task/name "Stock market library"
-       :task/done false
-       :permission/uuid "uktdkafojea"
-       :task/pinned true
-       :task/category (:db/id work-stuff)}
-      {:db/id (tempid)
-       :permission/level 34
-       :permission/uuid "uktdkafojea"}
-      {:db/id (tempid)
-       :permission/level 54
-       :permission/uuid "sieojeiofja"}
-      {:db/id (tempid)
-       :permission/level 10
-       :permission/uuid "bmmsmsdlfds"}])))
+(defn admin-filter
+  "A non-admin is not allowed to see a user's password hash."
+  [db datom] (not (ident= db (->a datom) :user/password-hash)))
+
+(defn user-filter
+  "A user is not allowed to see another user's location, nor their private repos."
+  [{:as dcfg :keys [q* entity]} username]
+  (fn [db datom]
+    (and (admin-filter db datom)
+         (let [e (->e datom)
+               a (->ident db (->a datom))
+               [user*] (q* [:find ['?user] :where ['?user :user/username username]] db)
+               other-users-location? (and (= a :user/location) (not= e user*))
+               part-of-repo?   (= (namespace a) "repo")
+               part-of-commit? (= (namespace a) "repo.commit")
+               other-users-private-repo?
+                 (fn [repo-e] (let [repo (entity db repo-e)]
+                                (and (-> repo :repo/owner :db/id (not= user*))
+                                     (-> repo :repo/private?))))
+               part-of-other-users-private-repo?
+                 (cond part-of-repo?   (other-users-private-repo? e)
+                       part-of-commit? (let [commit (entity db e)] (-> commit :repo.commit/to other-users-private-repo? :db/id))
+                       :else false)]
+           (not (or other-users-location? part-of-other-users-private-repo?))))))
+
+(defn ->git-commit
+  "Creates, but does not transact, a GitHub commit."
+  [{:as dcfg :keys [tempid]} to id]
+  (let [k-id (keyword (name to) (str id))]
+    {:db/id (tempid) :repo.commit/to [:repo/name to] :repo.commit/content (str k-id) :repo.commit/id k-id}))
+
+(defn populate! [conn {:as dcfg :keys [tempid transact!]}]
+  (let [mpdairy-id                    (tempid)
+        alexandergunnarson-id         (tempid)
+
+        mpdairy                    {:db/id         mpdairy-id
+                                    :user/username :mpdairy
+                                    :user/password-hash "mpdairy/hash"
+                                    :user/name     "Matt Parker"
+                                    :user/location :usa}
+        posh                       {:db/id         (tempid)
+                                    :repo/name     :posh
+                                    :repo/owner    mpdairy-id}
+        mpdairy-private            {:db/id         (tempid)
+                                    :repo/name     :mpdairy-private
+                                    :repo/owner    mpdairy-id :repo/private? true}
+
+        alexandergunnarson         {:db/id         alexandergunnarson-id
+                                    :user/username :alexandergunnarson
+                                    :user/password-hash "alexandergunnarson/hash"
+                                    :user/name     "Alex Gunnarson"
+                                    :user/location :utah}
+        quantum                    {:db/id         (tempid)
+                                    :repo/name     :quantum
+                                    :repo/owner    alexandergunnarson-id}
+        alexandergunnarson-private {:db/id         (tempid)
+                                    :repo/name     :alexandergunnarson-private
+                                    :repo/owner    alexandergunnarson-id :repo/private? true}]
+    (transact! conn
+      [mpdairy
+       posh
+       mpdairy-private
+       alexandergunnarson
+       quantum
+       alexandergunnarson-private])
+    (transact! conn
+      [(->git-commit dcfg :posh 0)
+       (->git-commit dcfg :posh 1)
+       (->git-commit dcfg :mpdairy-private 0)
+       (->git-commit dcfg :mpdairy-private 1)
+       (->git-commit dcfg :quantum 0)
+       (->git-commit dcfg :quantum 1)
+       (->git-commit dcfg :alexandergunnarson-private 0)
+       (->git-commit dcfg :alexandergunnarson-private 1)])))
 
 ; TODO remove this watch when query is removed from Posh tree
 ; TODO change Posh internals so datoms are calculated truly incrementally, such that a `set/difference` calculation becomes unnecessary
@@ -142,11 +167,12 @@
    Whatever `oldv` has that `newv` doesn't is assumed to be retracts.
    Then pipes this 'datom diff' to the provided core.async channel."
   [poshed lens-ks sub]
+  ;(prl lens-ks)
   (add-watch poshed lens-ks
     (fn [ks a oldv newv]
       (let [oldv (set (get-in oldv ks))
             newv (set (get-in newv ks))]
-        (when (not= oldv newv)
+        (when (not= oldv newv) (println "diff!")
           (let [adds     (set/difference newv oldv)
                 retracts (set/difference oldv newv)]
             (when (or (seq adds) (seq retracts))
@@ -162,41 +188,74 @@
     [:cache [:q q (into [[:db db-name]] in)] :datoms-t db-name]
     to-chan))
 
-(defn with-comms
-  "Establishes core.async communications channel for simulated server and client,
-   ensuring they are closed in a `finally` statement after calling the provided fn."
+(defn with-channels
+  "Establishes core.async communications channel for simulated server and client
+   (with two logged in users and an admin, with server and client channels for each),
+   ensuring they are all closed in a `finally` statement after calling the provided fn."
   [f]
-  (let [server-sub (chan 100)
-        client-sub (chan 100)]
-    (try (f server-sub client-sub)
-      (finally
-        (close! server-sub)
-        (close! client-sub)))))
+  (let [admin-server-sub              (chan 100)
+        mpdairy-server-sub            (chan 100)
+        alexandergunnarson-server-sub (chan 100)
 
-(def q
-  '[:find ?tname ?t ?uuid ?p ?level
-    :in $ ?level
+        admin-client-sub              (chan 100)
+        mpdairy-client-sub            (chan 100)
+        alexandergunnarson-client-sub (chan 100)
+
+        chans {:ads admin-server-sub
+               :mps mpdairy-server-sub
+               :ags alexandergunnarson-server-sub
+
+               :adc admin-client-sub
+               :mpc mpdairy-client-sub
+               :agc alexandergunnarson-client-sub}]
+    (try (f chans)
+      (finally (doseq [c (vals chans)] (close! c))))))
+
+(def user-public-q
+  '[:find ?username ?name
     :where
-      [?t :task/name        ?tname]
-      [?t :permission/uuid  ?uuid]
-      [?p :permission/uuid  ?uuid]
-      [?p :permission/level ?level]])
+      [?u :user/username      ?username]
+      [?u :user/name          ?name]])
 
-(def q-filtered
-  '[:find ?t ?uuid ?p ?level
-    :in $ ?level
+(def user-private-q
+  '[:find ?username ?name ?location
     :where
-      [?t :permission/uuid  ?uuid]
-      [?p :permission/uuid  ?uuid]
-      [?p :permission/level ?level]])
+      [?u :user/username      ?username]
+      [?u :user/name          ?name]
+      [?u :user/location      ?location]])
 
-(defn init-db! [{:keys [conn poshed dcfg to-chan]}]
+(def user-admin-q
+  '[:find ?username ?name ?location ?password-hash
+    :where
+      [?u :user/username      ?username]
+      [?u :user/name          ?name]
+      [?u :user/location      ?location]
+      [?u :user/password-hash ?password-hash]])
+
+(def repo-q ; public/private depending on the db passed in
+  '[:find ?name ?r ?id ?content
+    :where
+      [?r :repo/name           ?name]
+      [?c :repo.commit/to      ?r]
+      [?c :repo.commit/id      ?id]
+      [?c :repo.commit/content ?content]])
+
+(defn init-db! [{:keys [conn poshed dcfg admin mpdairy alexandergunnarson]}]
   (populate! conn dcfg)
-  (-> poshed
-      (#(st/add-q q (with-meta [:db :conn0] {:posh %}) 54))
-      (#(st/add-db (-> % meta :posh) :filtered conn schema {:filter no-task-names-filter})))
-  (sub-datoms! poshed :filtered to-chan q          54)
-  (sub-datoms! poshed :filtered to-chan q-filtered 54))
+  (st/add-db poshed :mpdairy            conn schema {:filter (user-filter dcfg :mpdairy)})
+  (st/add-db poshed :alexandergunnarson conn schema {:filter (user-filter dcfg :alexandergunnarson)})
+  (sub-datoms! poshed :conn0                      admin              user-admin-q  )  ; admin   user info (unfiltered, i.e. from admin perspective)
+
+  (sub-datoms! poshed :mpdairy                    mpdairy            user-public-q )  ; public  user info @mpdairy            can see
+  (sub-datoms! poshed :mpdairy                    mpdairy            user-private-q)  ; private user info @mpdairy            can see
+  (sub-datoms! poshed :mpdairy                    mpdairy            user-admin-q  )  ; admin   user info @mpdairy            can see (i.e. none)
+  (sub-datoms! poshed :mpdairy                    mpdairy            repo-q        )  ; repo         info @mpdairy            can see
+
+  (sub-datoms! poshed :alexandergunnarson         alexandergunnarson user-public-q )  ; public  user info @alexandergunnarson can see
+  (sub-datoms! poshed :alexandergunnarson         alexandergunnarson user-private-q)  ; private user info @alexandergunnarson can see
+  (sub-datoms! poshed :alexandergunnarson         alexandergunnarson user-admin-q  )  ; admin   user info @alexandergunnarson can see (i.e. none)
+  (sub-datoms! poshed :alexandergunnarson         alexandergunnarson repo-q        )) ; repo         info @alexandergunnarson can see
+
 
 (defn test-filtered
   [{:as args
@@ -230,13 +289,11 @@
     (dotimes [i n] (conj! ret (<!! c)))
     (persistent! ret))))
 
-(def dcfg-dat {:tempid ldat/tempid :transact! pdat/transact!})
-(def dcfg-ds  {:tempid lds/tempid  :transact! pds/transact! })
+(def dcfg-dat {:tempid ldat/tempid :transact! pdat/transact! :q* dat/q :entity dat/entity})
+(def dcfg-ds  {:tempid lds/tempid  :transact! pds/transact!  :q* ds/q  :entity ds/entity})
 
-; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
-; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
-; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
-#?(:clj
+
+#_(:clj
 (deftest simple-filtered-local-sync:datomic<->datascript
   (ldat/with-posh-conn pdat/dcfg [:datoms-t] "datomic:mem://test"
     schema
@@ -271,26 +328,42 @@
                            [{:adds #{[277076930200558 :permission/uuid "sieojeiofja" 13194139534331]}
                              :retracts #{}}]))]))))))))
 
-; TODO clean up the dataset and target it more to what we need
+(defn report-while-open! [id c]
+  (go-loop [] ; Simulates e.g. server-side websocket receive (client push)
+              ;             or client-side websocket receive (server push)
+    (when-let [msg (<! c)]
+      (debug (str "Received to " id) msg)
+      (recur))))
+
+(defn query-cache [poshed]
+  (->> @poshed :cache
+       (filter (fn [[k _]] (-> k first (= :q))))
+       (map (fn [[k v]] [k (-> v :datoms-t first second set)]))))
+
+; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
+; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
+; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
 #?(:clj
 (deftest filtered-local-sync:datomic<->datascript
   (ldat/with-posh-conn pdat/dcfg [:datoms-t] "datomic:mem://test"
     schema
     (fn [dat-poshed dat]
-      (with-comms
-        (fn [server-sub client-sub]
+      (with-channels
+        (fn [{:keys [ads mps ags , adc mpc agc]}] ; see `with-channels` for what these stand for
           (let [ds        (ds/create-conn (lds/->schema schema))
                 ds-poshed (pds/posh-one! ds [:datoms-t])
-                ; TODO simplify the below using `st/datoms-t`
-                lens-ks-filtered [:cache [:q q-filtered [[:db :filtered] 54]] :datoms-t :filtered]]
-            (init-db! {:conn dat :poshed dat-poshed :dcfg dcfg-dat :to-chan client-sub})
-            (init-db! {:conn ds  :poshed ds-poshed  :dcfg dcfg-ds  :to-chan server-sub})
-            (go-loop [] ; Simulates server-side websocket receive (client push)
-              (when-let [msg (<! server-sub)]
-                (debug "Received server message" msg)
-                (recur)))
-            (go-loop [] ; Simulates client-side websocket receive (server push)
-              (when-let [msg (<! client-sub)]
-                (debug "Received client message" msg)
-                (recur)))
+                ]
+            (init-db! {:conn dat :poshed dat-poshed :dcfg dcfg-dat :admin ads :mpdairy mps :alexandergunnarson ags})
+            (init-db! {:conn ds  :poshed ds-poshed  :dcfg dcfg-ds  :admin adc :mpdairy mpc :alexandergunnarson agc})
+            (report-while-open! :admin-server              ads)
+            (report-while-open! :mpdairy-server            mps)
+            (report-while-open! :alexandergunnarson-server mps)
+
+            (report-while-open! :admin-client              adc)
+            (report-while-open! :mpdairy-client            mpc)
+            (report-while-open! :alexandergunnarson-client mpc)
+            (pdat/transact! dat [(->git-commit dcfg-dat :posh 0)])
+            (pds/transact!  ds  [(->git-commit dcfg-ds  :posh 0)])
+            #_(prl (query-cache dat-poshed))
+
             )))))))

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -17,28 +17,38 @@
                  :cljs :refer-macros) [debug prl]]))
 
 (def schema
-  {:todo/name             {:db/valueType   :db.type/string
-                           :db/unique      :db.unique/identity
-                           :db/cardinality :db.cardinality/one}
-   :todo/owner            {:db/valueType   :db.type/ref
+  {:category/name         {:db/valueType   :db.type/string
+                           :db/cardinality :db.cardinality/one
+                           :db/unique      :db.unique/identity}
+   :category/todo         {:db/valueType   :db.type/ref
                            :db/cardinality :db.cardinality/one}
    :task/category         {:db/valueType   :db.type/ref
                            :db/cardinality :db.cardinality/one}
-   :category/todo         {:db/valueType   :db.type/ref
+   :task/done             {:db/valueType   :db.type/boolean
                            :db/cardinality :db.cardinality/one}
    :task/name             {:db/valueType   :db.type/string
                            :db/cardinality :db.cardinality/one
                            :db/unique      :db.unique/identity}
-   :category/name         {:db/valueType   :db.type/string
-                           :db/cardinality :db.cardinality/one
-                           :db/unique      :db.unique/identity}
+   :task/pinned           {:db/valueType   :db.type/boolean
+                           :db/cardinality :db.cardinality/one}
    :todo/display-category {:db/valueType   :db.type/ref
+                           :db/cardinality :db.cardinality/one}
+   :todo/listing          {:db/valueType   :db.type/keyword
+                           :db/cardinality :db.cardinality/one}
+   :todo/name             {:db/valueType   :db.type/string
+                           :db/unique      :db.unique/identity
                            :db/cardinality :db.cardinality/one}
    :todo/numbers          {:db/valueType   :db.type/long
                            :db/cardinality :db.cardinality/many}
+   :todo/owner            {:db/valueType   :db.type/ref
+                           :db/cardinality :db.cardinality/one}
    :permission/level      {:db/valueType   :db.type/long
                            :db/cardinality :db.cardinality/one}
    :permission/uuid       {:db/valueType   :db.type/string
+                           :db/cardinality :db.cardinality/one}
+   :person/age            {:db/valueType   :db.type/long
+                           :db/cardinality :db.cardinality/one}
+   :person/name           {:db/valueType   :db.type/string
                            :db/cardinality :db.cardinality/one}})
 
 (defn no-task-names-filter [_ datom] (not= (second datom) :task/name))
@@ -98,6 +108,8 @@
        :permission/level 10
        :permission/uuid "bmmsmsdlfds"}])))
 
+; TODO it seems this requires the datom matcher to call `seq` on a Datomic datom
+; TODO use posh.stateful for all this
 (defn tree [conn dcfg]
   (-> (p/empty-tree dcfg [:datoms-t])
       (p/add-db :hux conn schema)
@@ -133,42 +145,58 @@
 ; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
 
 ; TODO use filtered DB
-; TODO fix NPE with `populate!`
 #?(:clj
 (deftest local-sync:datomic<->datascript
   (ldat/with-posh-conn pdat/dcfg [:datoms-t] "datomic:mem://test"
     schema
-    #_[{:db/ident       :test/attr
-      :db/valueType   :db.type/string
-      :db/cardinality :db.cardinality/one}]
     (fn [dat-poshed dat]
-      tree
-      (let [;dat-tree  (tree dat pdat/dcfg)
-            ;_         (populate! dat {:tempid lds/tempid :transact! pds/transact!})
-            q         '[:find ?tname ?t ?uuid ?p ?level
-                        :in $hux ?level
-                        :where
-                        [$hux ?t :task/name        ?tname]
-                        [$hux ?t :permission/uuid  ?uuid]
-                        [$hux ?p :permission/uuid  ?uuid]
-                        [$hux ?p :permission/level ?level]]
-            dat-tree  (-> (st/new-posh pdat/dcfg [:datoms-t])
-                          (st/add-db :dat dat schema)
-                          (#(st/add-q q % 54))
-                          meta :posh)
+      (let [q '[:find ?tname ?t ?uuid ?p ?level
+                :in $ ?level
+                :where
+                  [?t :task/name        ?tname]
+                  [?t :permission/uuid  ?uuid]
+                  [?p :permission/uuid  ?uuid]
+                  [?p :permission/level ?level]]
+            ; DATOMIC
+            _ (populate! dat {:tempid ldat/tempid :transact! pdat/transact!})
+            ;dat-tree  (tree dat pdat/dcfg)
+            dat-tree (-> (st/new-posh pdat/dcfg [:datoms-t])
+                         (st/add-db :dat dat schema)
+                         (#(st/add-q q % 54))
+                         meta :posh)
+            ; TODO simplify the below using `st/datoms-t`
+            necessary-datoms-dat (-> dat-tree deref :cache (get [:q q [[:db :dat] 54]]) :datoms-t :dat)
+            _ (is (= necessary-datoms-dat
+                     #{[285873023222775 :permission/level 54                        13194139534315]
+                       [285873023222771 :permission/uuid  "sieojeiofja"             13194139534315]
+                       [285873023222770 :permission/uuid  "sieojeiofja"             13194139534315]
+                       [285873023222770 :task/name        "Mop Floors"              13194139534315]
+                       [285873023222775 :permission/uuid  "sieojeiofja"             13194139534315]
+                       [285873023222771 :task/name        "Draw a picture of a cat" 13194139534315]}))
+            _ (is (= @(pdat/q q dat 54)
+                     #{["Draw a picture of a cat" 285873023222771 "sieojeiofja" 285873023222775 54]
+                       ["Mop Floors"              285873023222770 "sieojeiofja" 285873023222775 54]}))
+            ; DATASCRIPT
             ds        (ds/create-conn (lds/->schema schema))
             ds-poshed (pds/posh-one! ds [:datoms-t])
             _         (populate! ds {:tempid lds/tempid :transact! pds/transact!})
-            ;sub
-            ;_ (prl dat-tree)
             ;ds-tree   (tree ds pds/dcfg)
-            ;ds-sub  (pds/q  [:find '?e :where ['?e :test/attr]] ds)
+            ds-tree (-> (st/new-posh pds/dcfg [:datoms-t])
+                        (st/add-db :dat ds schema)
+                        (#(st/add-q q % 54))
+                        meta :posh)
+            necessary-datoms-ds (-> ds-tree deref :cache (get [:q q [[:db :dat] 54]]) :datoms-t :dat)
+            _ (is (= necessary-datoms-ds
+                     #{[7  :permission/uuid "sieojeiofja"             536870913]
+                       [7  :task/name       "Mop Floors"              536870913]
+                       [12 :permission/level 54                       536870913]
+                       [8  :task/name       "Draw a picture of a cat" 536870913]
+                       [8  :permission/uuid "sieojeiofja"             536870913]
+                       [12 :permission/uuid "sieojeiofja"             536870913]}))
+            _ (is (= @(pds/q q ds 54)
+                     #{["Mop Floors"              7 "sieojeiofja" 12 54]
+                       ["Draw a picture of a cat" 8 "sieojeiofja" 12 54]}))
             ;_       (r/add-eager-watch ds-sub  :ds  (fn [k a oldv newv] (prl "DS"  a oldv newv)))
-            ;dat-sub (pdat/q [:find '?e :where ['?e :test/attr]] dat)
             ;_       (r/add-eager-watch dat-sub :dat (fn [k a oldv newv] (prl "DAT" a oldv newv)))
             ]
-        ;(prl (meta dat-sub) dat-poshed ds-poshed)
-
-        )))
-
-  ))
+        )))))

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -167,12 +167,12 @@
             ; TODO simplify the below using `st/datoms-t`
             necessary-datoms-dat (-> dat-tree deref :cache (get [:q q [[:db :dat] 54]]) :datoms-t :dat)
             _ (is (= necessary-datoms-dat
-                     #{[285873023222775 :permission/level 54                        13194139534315]
-                       [285873023222771 :permission/uuid  "sieojeiofja"             13194139534315]
-                       [285873023222770 :permission/uuid  "sieojeiofja"             13194139534315]
+                     #{[285873023222770 :permission/uuid  "sieojeiofja"             13194139534315]
                        [285873023222770 :task/name        "Mop Floors"              13194139534315]
+                       [285873023222771 :task/name        "Draw a picture of a cat" 13194139534315]
+                       [285873023222771 :permission/uuid  "sieojeiofja"             13194139534315]
                        [285873023222775 :permission/uuid  "sieojeiofja"             13194139534315]
-                       [285873023222771 :task/name        "Draw a picture of a cat" 13194139534315]}))
+                       [285873023222775 :permission/level 54                        13194139534315]}))
             _ (is (= @(pdat/q q dat 54)
                      #{["Draw a picture of a cat" 285873023222771 "sieojeiofja" 285873023222775 54]
                        ["Mop Floors"              285873023222770 "sieojeiofja" 285873023222775 54]}))
@@ -187,12 +187,12 @@
                         meta :posh)
             necessary-datoms-ds (-> ds-tree deref :cache (get [:q q [[:db :dat] 54]]) :datoms-t :dat)
             _ (is (= necessary-datoms-ds
-                     #{[7  :permission/uuid "sieojeiofja"             536870913]
-                       [7  :task/name       "Mop Floors"              536870913]
-                       [12 :permission/level 54                       536870913]
-                       [8  :task/name       "Draw a picture of a cat" 536870913]
-                       [8  :permission/uuid "sieojeiofja"             536870913]
-                       [12 :permission/uuid "sieojeiofja"             536870913]}))
+                     #{[7  :permission/uuid  "sieojeiofja"             536870913]
+                       [7  :task/name        "Mop Floors"              536870913]
+                       [8  :task/name        "Draw a picture of a cat" 536870913]
+                       [8  :permission/uuid  "sieojeiofja"             536870913]
+                       [12 :permission/uuid  "sieojeiofja"             536870913]
+                       [12 :permission/level 54                        536870913]}))
             _ (is (= @(pds/q q ds 54)
                      #{["Mop Floors"              7 "sieojeiofja" 12 54]
                        ["Draw a picture of a cat" 8 "sieojeiofja" 12 54]}))

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -4,9 +4,19 @@
               #?(:clj  :refer
                  :cljs :refer-macros) [is deftest testing]]))
 
+#_(do (require '[clojure.tools.namespace.repl :refer [refresh]])
+      (reset! posh.lib.util/debug? true)
+      (refresh)
+      (set! *warn-on-reflection* true)
+      (eval `(do (clojure.test/run-tests 'posh.lib.ratom-test)
+                 (clojure.test/run-tests 'posh.clj.datascript-test)
+                 (clojure.test/run-tests 'posh.clj.datomic-test)
+                 (clojure.test/run-tests 'posh.sync-test))))
+
 #?(:clj
 (deftest local-sync:datomic<->datascript
   ; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
   ; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
   ; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
+
   ))

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -284,6 +284,81 @@
 (defn get-in-cache [poshed db-name q & in]
   (get-in @poshed [:cache [:q q (into [[:db db-name]] in)] :datoms-t db-name]))
 
+(defn test-db-initialization
+  [poshed type]
+  (testing "DB initialization"
+    (let [user-tx-id                      (case type :dat 13194139534315  :ds 536870913)
+          repo-tx-id                      (case type :dat 13194139534322  :ds 536870914)
+          id                              (case type :dat 277076930200556 :ds 1)
+          reified-txn-ct                  (case type :dat 1               :ds 0)
+          r                               reified-txn-ct
+          mpdairy-public                  #{[(+ id 0)        :user/username       :mpdairy                         user-tx-id]
+                                            [(+ id 0)        :user/name           "Matt Parker"                    user-tx-id]}
+          mpdairy-private                 #{[(+ id 0)        :user/location       :usa                             user-tx-id]}
+          mpdairy-admin                   #{[(+ id 0)        :user/password-hash  "mpdairy/hash"                   user-tx-id]}
+          mpdairy                         (set/union mpdairy-public mpdairy-private mpdairy-admin)
+          posh                            #{[(+ id 1)        :repo/name           :posh                            user-tx-id]
+                                            [(+ id 6  r)     :repo.commit/to      (+ id 1)                         repo-tx-id]
+                                            [(+ id 6  r)     :repo.commit/id      :posh/_0                         repo-tx-id]
+                                            [(+ id 6  r)     :repo.commit/content ":posh/_0"                       repo-tx-id]
+                                            [(+ id 7  r)     :repo.commit/to      (+ id 1)                         repo-tx-id]
+                                            [(+ id 7  r)     :repo.commit/id      :posh/_1                         repo-tx-id]
+                                            [(+ id 7  r)     :repo.commit/content ":posh/_1"                       repo-tx-id]}
+          mpdairy-private-repo            #{[(+ id 2)        :repo/name           :mpdairy-private                 user-tx-id]
+                                            [(+ id 8  r)     :repo.commit/to      (+ id 2)                         repo-tx-id]
+                                            [(+ id 8  r)     :repo.commit/id      :mpdairy-private/_0              repo-tx-id]
+                                            [(+ id 8  r)     :repo.commit/content ":mpdairy-private/_0"            repo-tx-id]
+                                            [(+ id 9  r)     :repo.commit/to      (+ id 2)                         repo-tx-id]
+                                            [(+ id 9  r)     :repo.commit/id      :mpdairy-private/_1              repo-tx-id]
+                                            [(+ id 9  r)     :repo.commit/content ":mpdairy-private/_1"            repo-tx-id]}
+
+          alexandergunnarson-public       #{[(+ id 3)        :user/username       :alexandergunnarson              user-tx-id]
+                                            [(+ id 3)        :user/name           "Alex Gunnarson"                 user-tx-id]}
+          alexandergunnarson-private      #{[(+ id 3)        :user/location       :utah                            user-tx-id]}
+          alexandergunnarson-admin        #{[(+ id 3)        :user/password-hash  "alexandergunnarson/hash"        user-tx-id]}
+          alexandergunnarson              (set/union alexandergunnarson-public alexandergunnarson-private alexandergunnarson-admin)
+          quantum                         #{[(+ id 4)        :repo/name           :quantum                         user-tx-id]
+                                            [(+ id 10 r)     :repo.commit/id      :quantum/_0                      repo-tx-id]
+                                            [(+ id 10 r)     :repo.commit/to      (+ id 4)                         repo-tx-id]
+                                            [(+ id 10 r)     :repo.commit/content ":quantum/_0"                    repo-tx-id]
+                                            [(+ id 11 r)     :repo.commit/id      :quantum/_1                      repo-tx-id]
+                                            [(+ id 11 r)     :repo.commit/content ":quantum/_1"                    repo-tx-id]
+                                            [(+ id 11 r)     :repo.commit/to      (+ id 4)                         repo-tx-id]}
+          alexandergunnarson-private-repo #{[(+ id 5)        :repo/name           :alexandergunnarson-private      user-tx-id]
+                                            [(+ id 12 r)     :repo.commit/id      :alexandergunnarson-private/_0   repo-tx-id]
+                                            [(+ id 12 r)     :repo.commit/to      (+ id 5)                         repo-tx-id]
+                                            [(+ id 12 r)     :repo.commit/content ":alexandergunnarson-private/_0" repo-tx-id]
+                                            [(+ id 13 r)     :repo.commit/content ":alexandergunnarson-private/_1" repo-tx-id]
+                                            [(+ id 13 r)     :repo.commit/to      (+ id 5)                         repo-tx-id]
+                                            [(+ id 13 r)     :repo.commit/id      :alexandergunnarson-private/_1   repo-tx-id]}]
+      (testing "user-public-q"
+        (doseq [username #{:mpdairy :alexandergunnarson}]
+          (testing username
+            (is (= (get-in-cache poshed username user-public-q)
+                   (set/union mpdairy-public alexandergunnarson-public))))))
+      (testing "user-private-q"
+        (testing :mpdairy
+          (is (= (get-in-cache poshed :mpdairy user-private-q)
+                 (set/union mpdairy-public mpdairy-private))))
+        (testing :alexandergunnarson
+          (is (= (get-in-cache poshed :alexandergunnarson user-private-q)
+                 (set/union alexandergunnarson-public alexandergunnarson-private)))))
+      (testing "user-admin-q"
+        (testing :admin
+          (is (= (get-in-cache poshed :conn0 user-admin-q)
+                 (set/union mpdairy alexandergunnarson))))
+        (doseq [username #{:mpdairy :alexandergunnarson}]
+          (testing username
+            (is (= (get-in-cache poshed username user-admin-q)
+                   nil)))))
+      (testing "repo-q"
+        (testing :mpdairy
+          (is (= (get-in-cache poshed :mpdairy repo-q)
+                 (set/union posh mpdairy-private-repo quantum))))
+        (testing :alexandergunnarson
+          (is (= (get-in-cache poshed :alexandergunnarson repo-q)
+                 (set/union quantum alexandergunnarson-private-repo posh))))))))
+
 ; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
 ; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
 ; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
@@ -306,78 +381,12 @@
               (report-while-open! :admin-client              adc)
               (report-while-open! :mpdairy-client            mpc)
               (report-while-open! :alexandergunnarson-client mpc))
-            (testing "DB initialization"
-              (let [mpdairy-public                  #{[277076930200556 :user/username       :mpdairy                         13194139534315]
-                                                      [277076930200556 :user/name           "Matt Parker"                    13194139534315]}
-                    mpdairy-private                 #{[277076930200556 :user/location       :usa                             13194139534315]}
-                    mpdairy-admin                   #{[277076930200556 :user/password-hash  "mpdairy/hash"                   13194139534315]}
-                    mpdairy                         (set/union mpdairy-public mpdairy-private mpdairy-admin)
-                    posh                            #{[277076930200557 :repo/name           :posh                            13194139534315]
-                                                      [277076930200563 :repo.commit/to      277076930200557                  13194139534322]
-                                                      [277076930200563 :repo.commit/id      :posh/_0                         13194139534322]
-                                                      [277076930200563 :repo.commit/content ":posh/_0"                       13194139534322]
-                                                      [277076930200564 :repo.commit/to      277076930200557                  13194139534322]
-                                                      [277076930200564 :repo.commit/id      :posh/_1                         13194139534322]
-                                                      [277076930200564 :repo.commit/content ":posh/_1"                       13194139534322]}
-                    mpdairy-private-repo            #{[277076930200558 :repo/name           :mpdairy-private                 13194139534315]
-                                                      [277076930200565 :repo.commit/to      277076930200558                  13194139534322]
-                                                      [277076930200565 :repo.commit/id      :mpdairy-private/_0              13194139534322]
-                                                      [277076930200565 :repo.commit/content ":mpdairy-private/_0"            13194139534322]
-                                                      [277076930200566 :repo.commit/to      277076930200558                  13194139534322]
-                                                      [277076930200566 :repo.commit/id      :mpdairy-private/_1              13194139534322]
-                                                      [277076930200566 :repo.commit/content ":mpdairy-private/_1"            13194139534322]}
-
-                    alexandergunnarson-public       #{[277076930200559 :user/username       :alexandergunnarson              13194139534315]
-                                                      [277076930200559 :user/name           "Alex Gunnarson"                 13194139534315]}
-                    alexandergunnarson-private      #{[277076930200559 :user/location       :utah                            13194139534315]}
-                    alexandergunnarson-admin        #{[277076930200559 :user/password-hash  "alexandergunnarson/hash"        13194139534315]}
-                    alexandergunnarson              (set/union alexandergunnarson-public alexandergunnarson-private alexandergunnarson-admin)
-                    quantum                         #{[277076930200560 :repo/name           :quantum                         13194139534315]
-                                                      [277076930200567 :repo.commit/id      :quantum/_0                      13194139534322]
-                                                      [277076930200567 :repo.commit/to      277076930200560                  13194139534322]
-                                                      [277076930200567 :repo.commit/content ":quantum/_0"                    13194139534322]
-                                                      [277076930200568 :repo.commit/id      :quantum/_1                      13194139534322]
-                                                      [277076930200568 :repo.commit/content ":quantum/_1"                    13194139534322]
-                                                      [277076930200568 :repo.commit/to      277076930200560                  13194139534322]}
-                    alexandergunnarson-private-repo #{[277076930200561 :repo/name           :alexandergunnarson-private      13194139534315]
-                                                      [277076930200569 :repo.commit/id      :alexandergunnarson-private/_0   13194139534322]
-                                                      [277076930200569 :repo.commit/to      277076930200561                  13194139534322]
-                                                      [277076930200569 :repo.commit/content ":alexandergunnarson-private/_0" 13194139534322]
-                                                      [277076930200570 :repo.commit/content ":alexandergunnarson-private/_1" 13194139534322]
-                                                      [277076930200570 :repo.commit/to      277076930200561                  13194139534322]
-                                                      [277076930200570 :repo.commit/id      :alexandergunnarson-private/_1   13194139534322]}]
-                (testing "user-public-q"
-                  (doseq [username #{:mpdairy :alexandergunnarson}]
-                    (testing username
-                      (is (= (get-in-cache dat-poshed username user-public-q)
-                             (set/union mpdairy-public alexandergunnarson-public))))))
-                (testing "user-private-q"
-                  (testing :mpdairy
-                    (is (= (get-in-cache dat-poshed :mpdairy user-private-q)
-                           (set/union mpdairy-public mpdairy-private))))
-                  (testing :alexandergunnarson
-                    (is (= (get-in-cache dat-poshed :alexandergunnarson user-private-q)
-                           (set/union alexandergunnarson-public alexandergunnarson-private)))))
-                (testing "user-admin-q"
-                  (testing :admin
-                    (is (= (get-in-cache dat-poshed :conn0 user-admin-q)
-                           (set/union mpdairy alexandergunnarson))))
-                  (doseq [username #{:mpdairy :alexandergunnarson}]
-                    (testing username
-                      (is (= (get-in-cache dat-poshed username user-admin-q)
-                             nil)))))
-                (testing "repo-q"
-                  (testing :mpdairy
-                    (is (= (get-in-cache dat-poshed :mpdairy repo-q)
-                           (set/union posh mpdairy-private-repo quantum))))
-                  (testing :alexandergunnarson
-                    (is (= (get-in-cache dat-poshed :alexandergunnarson repo-q)
-                           (set/union quantum alexandergunnarson-private-repo posh)))))))
-            #_(prl (query-cache dat-poshed))
+            (test-db-initialization dat-poshed :dat)
+            (test-db-initialization ds-poshed  :ds )
+            #_(prl (query-cache ds-poshed))
             ; TODO try retracts as well
             (pdat/transact! dat [(->git-commit dcfg-dat :posh 2)])
             (pds/transact!  ds  [(->git-commit dcfg-ds  :posh 2)])
-
 
             #_(is (= (take<!! 1 server-sub) ...))
 

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -2,21 +2,54 @@
   (:require [#?(:clj  clojure.test
                 :cljs cljs.test) :as test
               #?(:clj  :refer
-                 :cljs :refer-macros) [is deftest testing]]))
+                 :cljs :refer-macros) [is deftest testing]]
+    #?(:clj [datascript.core     :as ds])
+    #?(:clj [posh.clj.datascript :as pds]) ; TODO CLJC
+            [posh.lib.datascript :as lds]
+    #?(:clj [datomic.api         :as dat])
+    #?(:clj [posh.clj.datomic    :as pdat])
+    #?(:clj [posh.lib.datomic    :as ldat])
+            [posh.lib.ratom      :as r]
+            [posh.lib.util       :as u
+              #?(:clj  :refer
+                 :cljs :refer-macros) [debug prl]]))
 
-#_(do (require '[clojure.tools.namespace.repl :refer [refresh]])
-      (reset! posh.lib.util/debug? true)
-      (refresh)
-      (set! *warn-on-reflection* true)
-      (eval `(do (clojure.test/run-tests 'posh.lib.ratom-test)
-                 (clojure.test/run-tests 'posh.clj.datascript-test)
-                 (clojure.test/run-tests 'posh.clj.datomic-test)
-                 (clojure.test/run-tests 'posh.sync-test))))
+#_(try #_(clojure.main/repl
+           :print  clojure.pprint/pprint
+           :caught clojure.pprint/pprint)
+       (require '[clojure.tools.namespace.repl :refer [refresh]])
+       (let [x (refresh)] (when (instance? Throwable x) (throw x)))
+       (set! *warn-on-reflection* true)
+       (eval `(do (reset! posh.lib.util/debug? true)
+                  (clojure.test/run-tests 'posh.lib.ratom-test)
+                  (clojure.test/run-tests 'posh.clj.datascript-test)
+                  (clojure.test/run-tests 'posh.clj.datomic-test)
+                  (clojure.test/run-tests 'posh.sync-test)))
+    (catch Throwable t (println t)))
 
+; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
+; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
+; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
 #?(:clj
 (deftest local-sync:datomic<->datascript
-  ; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
-  ; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
-  ; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
+  (ldat/with-posh-conn [:datoms-t] "datomic:mem://test"
+    [{:db/ident       :test/attr
+      :db/valueType   :db.type/string
+      :db/cardinality :db.cardinality/one}]
+    (fn [dat]
+      (let [ds (ds/create-conn {:test/attr
+                                {;:db/valueType   :db.type/string
+                                 :db/cardinality :db.cardinality/one}})
+            _  (pds/posh-one! ds [:datoms-t])
+            ds-sub  (pds/q  [:find '?e :where ['?e :test/attr]] ds)
+            _       (r/add-eager-watch ds-sub  :ds  (fn [_ _ oldv newv] (prl "DS"  oldv newv)))
+            dat-sub (pdat/q [:find '?e :where ['?e :test/attr]] dat)
+            _       (r/add-eager-watch dat-sub :dat (fn [_ _ oldv newv] (prl "DAT" oldv newv)))]
+        (pds/transact! ds
+          [{:db/id     (lds/tempid)
+            :test/attr "A"}])
+        (pdat/transact! dat
+          [{:db/id     (ldat/tempid)
+            :test/attr "A"}]))))
 
   ))

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -176,6 +176,7 @@
           (let [adds     (set/difference newv oldv)
                 retracts (set/difference oldv newv)]
             (when (or (seq adds) (seq retracts))
+              ; Send all datoms for a given transaction as a contiguous package; don't stream them separately
               (offer! sub {:adds adds :retracts retracts}))))))))
 
 (defn sub-datoms!
@@ -383,11 +384,22 @@
               (report-while-open! :alexandergunnarson-client mpc))
             (test-db-initialization dat-poshed :dat)
             (test-db-initialization ds-poshed  :ds )
-            #_(prl (query-cache ds-poshed))
             ; TODO try retracts as well
             (pdat/transact! dat [(->git-commit dcfg-dat :posh 2)])
             (pds/transact!  ds  [(->git-commit dcfg-ds  :posh 2)])
 
             #_(is (= (take<!! 1 server-sub) ...))
 
+
             )))))))
+
+; ===== TODOS ===== ;
+
+; ----- TXN FNS ----- ;
+; Register tx-fns on both server and client
+
+; ----- SCHEMA CHANGES ----- ;
+; Client -> server is easy; server -> client is less so
+
+; ----- AUTH ----- ;
+; Pretty good right now; obviously some improvements are available

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -3,6 +3,7 @@
                 :cljs cljs.test) :as test
               #?(:clj  :refer
                  :cljs :refer-macros) [is deftest testing]]
+            [posh.core           :as p]
     #?(:clj [datascript.core     :as ds])
     #?(:clj [posh.clj.datascript :as pds]) ; TODO CLJC
             [posh.lib.datascript :as lds]
@@ -14,42 +15,142 @@
               #?(:clj  :refer
                  :cljs :refer-macros) [debug prl]]))
 
-#_(try #_(clojure.main/repl
-           :print  clojure.pprint/pprint
-           :caught clojure.pprint/pprint)
-       (require '[clojure.tools.namespace.repl :refer [refresh]])
-       (let [x (refresh)] (when (instance? Throwable x) (throw x)))
-       (set! *warn-on-reflection* true)
-       (eval `(do (reset! posh.lib.util/debug? true)
-                  (clojure.test/run-tests 'posh.lib.ratom-test)
-                  (clojure.test/run-tests 'posh.clj.datascript-test)
-                  (clojure.test/run-tests 'posh.clj.datomic-test)
-                  (clojure.test/run-tests 'posh.sync-test)))
-    (catch Throwable t (println t)))
+(def schema
+  {:todo/name             {:db/valueType   :db.type/string
+                           :db/unique      :db.unique/identity
+                           :db/cardinality :db.cardinality/one}
+   :todo/owner            {:db/valueType   :db.type/ref
+                           :db/cardinality :db.cardinality/one}
+   :task/category         {:db/valueType   :db.type/ref
+                           :db/cardinality :db.cardinality/one}
+   :category/todo         {:db/valueType   :db.type/ref
+                           :db/cardinality :db.cardinality/one}
+   :task/name             {:db/valueType   :db.type/string
+                           :db/cardinality :db.cardinality/one
+                           :db/unique      :db.unique/identity}
+   :category/name         {:db/valueType   :db.type/string
+                           :db/cardinality :db.cardinality/one
+                           :db/unique      :db.unique/identity}
+   :todo/display-category {:db/valueType   :db.type/ref
+                           :db/cardinality :db.cardinality/one}
+   :todo/numbers          {:db/valueType   :db.type/long
+                           :db/cardinality :db.cardinality/many}})
+
+(defn no-task-names-filter [_ datom] (not= (second datom) :task/name))
+
+(defn populate! [conn {:keys [tempid transact!] :as dcfg}]
+  (let [matt       {:db/id (tempid) :person/name "Matt" :person/age 14}
+        todos      {:db/id (tempid)
+                    :todo/name "Matt's List" :todo/listing :all
+                    :todo/owner (:db/id matt)}
+        at-home    {:db/id (tempid) :category/name "At Home"    :category/todo (:db/id todos)}
+        work-stuff {:db/id (tempid) :category/name "Work Stuff" :category/todo (:db/id todos)}
+        hobby      {:db/id (tempid) :category/name "Hobby"      :category/todo (:db/id todos)}]
+    (transact!
+     conn
+     [matt
+      todos
+      at-home
+      work-stuff
+      hobby
+      [:db/add (:db/id todos) :todo/numbers 12]
+      [:db/add (:db/id todos) :todo/numbers 20]
+      [:db/add (:db/id todos) :todo/numbers 443]
+      {:db/id (tempid)
+       :task/name "Clean Dishes"
+       :task/done true
+       :permission/uuid "uktdkafojea"
+       :task/category (:db/id at-home)}
+      {:db/id (tempid)
+       :task/name "Mop Floors"
+       :task/done true
+       :task/pinned true
+       :permission/uuid "sieojeiofja"
+       :task/category (:db/id at-home)}
+      {:db/id (tempid)
+       :task/name "Draw a picture of a cat"
+       :task/done false
+       :permission/uuid "sieojeiofja"
+       :task/category (:db/id hobby)}
+      {:db/id (tempid)
+       :task/name "Compose opera"
+       :task/done true
+       :permission/uuid "bmmsmsdlfds"
+       :task/category (:db/id hobby)}
+      {:db/id (tempid)
+       :task/name "Stock market library"
+       :task/done false
+       :permission/uuid "uktdkafojea"
+       :task/pinned true
+       :task/category (:db/id work-stuff)}
+      {:db/id (tempid)
+       :permission/level 34
+       :permission/uuid "uktdkafojea"}
+      {:db/id (tempid)
+       :permission/level 54
+       :permission/uuid "sieojeiofja"}
+      {:db/id (tempid)
+       :permission/level 10
+       :permission/uuid "bmmsmsdlfds"}])))
+
+(defn tree [conn dcfg]
+  (-> (p/empty-tree dcfg [:datoms-t])
+      (p/add-db :hux conn schema)
+
+      ;; same db as :hux but without any :task/name datoms
+      (p/add-db :tasks conn schema {:filter 'no-task-names-filter}) ; TODO make so it doesn't call `resolve`
+
+      (p/add-pull [:db :hux] '[*] 3)
+      (p/add-filter-tx [:db :hux] '[[_ #{:category/name}]])
+      (p/add-filter-pull
+       [:db :hux]
+       '[{:todo/_owner [{:category/_todo [:category/name]}]}] 1)
+      (p/add-pull
+       '[:filter-pull
+         [:db :hux]
+         [{:todo/_owner [{:category/_todo [:category/name]}]}]
+         1]
+       '[*] 3)
+      (p/add-pull '[:filter-tx [:db :hux] [[_ #{:category/name}]]]
+                  '[*] 3)
+      (p/add-q '[:find ?tname ?t ?uuid ?p ?level
+                 :in $hux ?level
+                 :where
+                 [?t :task/name ?tname]
+                 [?t :permission/uuid ?uuid]
+                 [$hux ?p :permission/uuid ?uuid]
+                 [$hux ?p :permission/level ?level]]
+               [:db :hux]
+               54)))
 
 ; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
 ; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
 ; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
 #?(:clj
 (deftest local-sync:datomic<->datascript
-  (ldat/with-posh-conn [:datoms-t] "datomic:mem://test"
-    [{:db/ident       :test/attr
+  (ldat/with-posh-conn pdat/dcfg [:datoms-t] "datomic:mem://test"
+    schema
+    #_[{:db/ident       :test/attr
       :db/valueType   :db.type/string
       :db/cardinality :db.cardinality/one}]
-    (fn [dat]
-      (let [ds (ds/create-conn {:test/attr
-                                {;:db/valueType   :db.type/string
-                                 :db/cardinality :db.cardinality/one}})
-            _  (pds/posh-one! ds [:datoms-t])
-            ds-sub  (pds/q  [:find '?e :where ['?e :test/attr]] ds)
-            _       (r/add-eager-watch ds-sub  :ds  (fn [_ _ oldv newv] (prl "DS"  oldv newv)))
-            dat-sub (pdat/q [:find '?e :where ['?e :test/attr]] dat)
-            _       (r/add-eager-watch dat-sub :dat (fn [_ _ oldv newv] (prl "DAT" oldv newv)))]
-        (pds/transact! ds
-          [{:db/id     (lds/tempid)
-            :test/attr "A"}])
-        (pdat/transact! dat
-          [{:db/id     (ldat/tempid)
-            :test/attr "A"}]))))
+    (fn [dat-poshed dat]
+      tree
+      (let [;dat-tree  (tree dat pdat/dcfg)
+            dat-tree  (-> (p/empty-tree pdat/dcfg [:datoms-t])
+                          (p/add-db :dat dat schema)
+                          )
+            ds        (ds/create-conn (lds/->schema schema))
+            ds-poshed (pds/posh-one! ds [:datoms-t])
+            ;ds-tree   (tree ds pds/dcfg)
+            ;_ (populate! dat {:tempid lds/tempid :transact! pds/transact!})
+            ;_ (populate! ds  {:tempid lds/tempid :transact! pds/transact!})
+            ;ds-sub  (pds/q  [:find '?e :where ['?e :test/attr]] ds)
+            ;_       (r/add-eager-watch ds-sub  :ds  (fn [k a oldv newv] (prl "DS"  a oldv newv)))
+            ;dat-sub (pdat/q [:find '?e :where ['?e :test/attr]] dat)
+            ;_       (r/add-eager-watch dat-sub :dat (fn [k a oldv newv] (prl "DAT" a oldv newv)))
+            ]
+        ;(prl (meta dat-sub) dat-poshed ds-poshed)
+
+        )))
 
   ))

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -256,33 +256,6 @@
   (sub-datoms! poshed :alexandergunnarson         alexandergunnarson user-admin-q  )  ; admin   user info @alexandergunnarson can see (i.e. none)
   (sub-datoms! poshed :alexandergunnarson         alexandergunnarson repo-q        )) ; repo         info @alexandergunnarson can see
 
-
-(defn test-filtered
-  [{:as args
-    :keys [poshed conn lens-ks lens-ks-empty lens-ks-filtered eid-0 eid-1 eid-2 tx-id to-chan]
-    {:keys [tempid transact!] :as dcfg} :dcfg}]
-  (let [_ (init-db! args)
-        necessary-datoms (-> poshed deref (get-in lens-ks))
-        _ (is (= necessary-datoms
-                 #{[eid-0 :permission/uuid  "sieojeiofja"             tx-id]
-                   [eid-0 :task/name        "Mop Floors"              tx-id]
-                   [eid-1 :task/name        "Draw a picture of a cat" tx-id]
-                   [eid-1 :permission/uuid  "sieojeiofja"             tx-id]
-                   [eid-2 :permission/uuid  "sieojeiofja"             tx-id]
-                   [eid-2 :permission/level 54                        tx-id]}))
-        necessary-datoms-empty (-> poshed deref (get-in lens-ks-empty))
-        _ (is (= necessary-datoms-empty nil))
-        necessary-datoms-filtered (-> poshed deref (get-in lens-ks-filtered))
-        _ (is (= necessary-datoms-filtered
-                 #{[eid-0 :permission/uuid  "sieojeiofja"             tx-id]
-                   [eid-1 :permission/uuid  "sieojeiofja"             tx-id]
-                   [eid-2 :permission/uuid  "sieojeiofja"             tx-id]
-                   [eid-2 :permission/level 54                        tx-id]}))
-        _ (transact! conn [[:db/add     [:task/name     "Mop Floors"             ] :task/name       "Mop All Floors"]])
-        _ (transact! conn [[:db/retract [:task/name     "Draw a picture of a cat"] :task/name       "Draw a picture of a cat"]
-                           [:db/add     [:task/name     "Mop All Floors"         ] :task/name       "Mop Some Floors"]])
-        _ (transact! conn [[:db/add     [:category/name "At Home"                ] :permission/uuid "sieojeiofja"]])]))
-
 #?(:clj
 (defn take<!! [n c]
   (let [ret (transient [])]

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -148,12 +148,12 @@
        quantum
        alexandergunnarson-private])
     (transact! conn
-      [(->git-commit dcfg :posh 0)
-       (->git-commit dcfg :posh 1)
-       (->git-commit dcfg :mpdairy-private 0)
-       (->git-commit dcfg :mpdairy-private 1)
-       (->git-commit dcfg :quantum 0)
-       (->git-commit dcfg :quantum 1)
+      [(->git-commit dcfg :posh                       0)
+       (->git-commit dcfg :posh                       1)
+       (->git-commit dcfg :mpdairy-private            0)
+       (->git-commit dcfg :mpdairy-private            1)
+       (->git-commit dcfg :quantum                    0)
+       (->git-commit dcfg :quantum                    1)
        (->git-commit dcfg :alexandergunnarson-private 0)
        (->git-commit dcfg :alexandergunnarson-private 1)])))
 
@@ -172,7 +172,7 @@
     (fn [ks a oldv newv]
       (let [oldv (set (get-in oldv ks))
             newv (set (get-in newv ks))]
-        (when (not= oldv newv) (println "diff!")
+        (when (not= oldv newv) (println "diff" lens-ks)
           (let [adds     (set/difference newv oldv)
                 retracts (set/difference oldv newv)]
             (when (or (seq adds) (seq retracts))
@@ -292,42 +292,6 @@
 (def dcfg-dat {:tempid ldat/tempid :transact! pdat/transact! :q* dat/q :entity dat/entity})
 (def dcfg-ds  {:tempid lds/tempid  :transact! pds/transact!  :q* ds/q  :entity ds/entity})
 
-
-#_(:clj
-(deftest simple-filtered-local-sync:datomic<->datascript
-  (ldat/with-posh-conn pdat/dcfg [:datoms-t] "datomic:mem://test"
-    schema
-    (fn [dat-poshed dat]
-      (with-comms
-        (fn [server-sub client-sub]
-          (let [ds        (ds/create-conn (lds/->schema schema))
-                ds-poshed (pds/posh-one! ds [:datoms-t])
-                ; TODO simplify the below using `st/datoms-t`
-                lens-ks          [:cache [:q q          [[:db :conn0   ] 54]] :datoms-t :conn0   ]
-                ; This query will have empty results because datoms with :task/name are filtered out
-                lens-ks-empty    [:cache [:q q          [[:db :filtered] 54]] :datoms-t :filtered]
-                lens-ks-filtered [:cache [:q q-filtered [[:db :filtered] 54]] :datoms-t :filtered]]
-            ; DATOMIC
-            (test-filtered
-              {:conn dat :poshed dat-poshed :to-chan client-sub
-               :lens-ks lens-ks :lens-ks-empty lens-ks-empty :lens-ks-filtered lens-ks-filtered
-               :eid-0 277076930200562 :eid-1 277076930200563 :eid-2 277076930200567 :tx-id 13194139534315
-               :dcfg dcfg-dat})
-            ; DATASCRIPT
-            (test-filtered
-              {:conn ds :poshed ds-poshed :to-chan server-sub
-               :lens-ks lens-ks :lens-ks-empty lens-ks-empty :lens-ks-filtered lens-ks-filtered
-               :eid-0 7 :eid-1 8 :eid-2 12 :tx-id 536870913
-               :dcfg dcfg-ds})
-            (let [server-ret (take<!! 1 server-sub)
-                  client-ret (take<!! 1 client-sub)
-                  _ (is (= server-ret
-                           [{:adds #{[3 :permission/uuid "sieojeiofja" 536870916]}
-                             :retracts #{}}]))
-                  _ (is (= client-ret
-                           [{:adds #{[277076930200558 :permission/uuid "sieojeiofja" 13194139534331]}
-                             :retracts #{}}]))]))))))))
-
 (defn report-while-open! [id c]
   (go-loop [] ; Simulates e.g. server-side websocket receive (client push)
               ;             or client-side websocket receive (server push)
@@ -340,6 +304,9 @@
        (filter (fn [[k _]] (-> k first (= :q))))
        (map (fn [[k v]] [k (-> v :datoms-t first second set)]))))
 
+(defn get-in-cache [poshed db-name q & in]
+  (get-in @poshed [:cache [:q q (into [[:db db-name]] in)] :datoms-t db-name]))
+
 ; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
 ; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
 ; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
@@ -351,19 +318,48 @@
       (with-channels
         (fn [{:keys [ads mps ags , adc mpc agc]}] ; see `with-channels` for what these stand for
           (let [ds        (ds/create-conn (lds/->schema schema))
-                ds-poshed (pds/posh-one! ds [:datoms-t])
-                ]
-            (init-db! {:conn dat :poshed dat-poshed :dcfg dcfg-dat :admin ads :mpdairy mps :alexandergunnarson ags})
-            (init-db! {:conn ds  :poshed ds-poshed  :dcfg dcfg-ds  :admin adc :mpdairy mpc :alexandergunnarson agc})
-            (report-while-open! :admin-server              ads)
-            (report-while-open! :mpdairy-server            mps)
-            (report-while-open! :alexandergunnarson-server mps)
+                ds-poshed (pds/posh-one! ds [:datoms-t])]
+            (testing "Filters and reports initialization"
+              (init-db! {:conn dat :poshed dat-poshed :dcfg dcfg-dat :admin ads :mpdairy mps :alexandergunnarson ags})
+              (init-db! {:conn ds  :poshed ds-poshed  :dcfg dcfg-ds  :admin adc :mpdairy mpc :alexandergunnarson agc})
+              (report-while-open! :admin-server              ads)
+              (report-while-open! :mpdairy-server            mps)
+              (report-while-open! :alexandergunnarson-server mps)
 
-            (report-while-open! :admin-client              adc)
-            (report-while-open! :mpdairy-client            mpc)
-            (report-while-open! :alexandergunnarson-client mpc)
-            (pdat/transact! dat [(->git-commit dcfg-dat :posh 0)])
-            (pds/transact!  ds  [(->git-commit dcfg-ds  :posh 0)])
+              (report-while-open! :admin-client              adc)
+              (report-while-open! :mpdairy-client            mpc)
+              (report-while-open! :alexandergunnarson-client mpc))
+            (testing "user-admin-q"
+              (testing "admin"
+                (is (= (get-in-cache dat-poshed :conn0 user-admin-q)
+                       #{[277076930200556 :user/username      :mpdairy                  13194139534315]
+                         [277076930200559 :user/location      :utah                     13194139534315]
+                         [277076930200556 :user/password-hash "mpdairy/hash"            13194139534315]
+                         [277076930200556 :user/location      :usa                      13194139534315]
+                         [277076930200559 :user/password-hash "alexandergunnarson/hash" 13194139534315]
+                         [277076930200559 :user/username      :alexandergunnarson       13194139534315]
+                         [277076930200556 :user/name          "Matt Parker"             13194139534315]
+                         [277076930200559 :user/name          "Alex Gunnarson"          13194139534315]})))
+              (doseq [username #{:mpdairy :alexandergunnarson}]
+                (testing username
+                  (is (= (get-in-cache dat-poshed username user-admin-q)
+                         nil)))))
+            (testing "user-public-q"
+              (doseq [username #{:mpdairy :alexandergunnarson}]
+                (testing username
+                  (is (= (get-in-cache dat-poshed username user-public-q)
+                         #{[277076930200556 :user/username :mpdairy            13194139534315]
+                           [277076930200559 :user/username :alexandergunnarson 13194139534315]
+                           [277076930200556 :user/name     "Matt Parker"       13194139534315]
+                           [277076930200559 :user/name     "Alex Gunnarson"    13194139534315]})))))
+            (testing ""
+              )
+
+            ; TODO try retracts as well
+            (pdat/transact! dat [(->git-commit dcfg-dat :posh 2)])
+            (pds/transact!  ds  [(->git-commit dcfg-ds  :posh 2)])
+
             #_(prl (query-cache dat-poshed))
+            #_(is (= (take<!! 1 server-sub) ...))
 
             )))))))

--- a/test/posh/sync_test.cljc
+++ b/test/posh/sync_test.cljc
@@ -1,0 +1,12 @@
+(ns posh.sync-test
+  (:require [#?(:clj  clojure.test
+                :cljs cljs.test) :as test
+              #?(:clj  :refer
+                 :cljs :refer-macros) [is deftest testing]]))
+
+#?(:clj
+(deftest local-sync:datomic<->datascript
+  ; A little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for
+  ; now, but focusing on sync itself) showing that the DataScript DB really only gets the subset
+  ; of the Datomic DB that it needs, and at that, only the authorized portions of that subset.
+  ))


### PR DESCRIPTION
(@metasoarous and I just talked a little on gitter about this)

I'm planning on this PR essentially being [Datsync](https://github.com/metasoarous/datsync) in a nutshell, though it'll likely be missing some functionality (at least in the beginning). Normally I would PR this code to Datsync itself, but according to @metasoarous it's in flux right now. This code might in the future be extracted and placed in Datsync but for now it seems as good a place as any to put it here and let people experiment with it.

The first step is to make a little sync test between Datomic and Clojure DataScript (i.e. ignoring websocket transport for now, but focusing on sync itself) showing that the DataScript DB really only gets the subset of the Datomic DB that it needs, and at that, only the authorized portions of that subset.