### PR TITLE
fix: plugin_base functions need dcfg as first argument

### DIFF
--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -17,9 +17,9 @@
     (vector? id)
     (if-let [eid ((:entid dcfg) db id)]
       ((:pull* dcfg) db query eid)
-      (missing-pull-result query))
+      (missing-pull-result dcfg query))
     (nil? id)
-    (missing-pull-result query)))
+    (missing-pull-result dcfg query)))
 
 ;; need to set last-tx-t in conn so that it doesn't try the same tx twice
 (defn set-conn-listener! [dcfg posh-atom conn db-id]
@@ -124,7 +124,7 @@
   "Returns a reaction of a pull expression. The options argument may specify `:cache :forever`, which keeps query results
   cached indefinitely, even if the reaction is disposed."
   ([dcfg poshdb pull-pattern eid options]
-   (let [true-poshdb (get-db poshdb)
+   (let [true-poshdb (get-db dcfg poshdb)
          storage-key [:pull true-poshdb pull-pattern eid]
          posh-atom   (get-posh-atom dcfg poshdb)]
      (make-query-reaction dcfg


### PR DESCRIPTION
Was playing with the latest posh today and came across some errors. This will fix them :)

FWIW when leiningen compiled the project there were warnings mentioning the arity issue.