### PR TITLE
Fix plugin-base/safe-pull so it checks for number? instead of integer?

### DIFF
--- a/src/posh/lib/pull_analyze.cljc
+++ b/src/posh/lib/pull_analyze.cljc
@@ -1,6 +1,7 @@
 (ns posh.lib.pull-analyze
   (:require [posh.lib.util :as util]
-            [posh.lib.datom-matcher :as dm]))
+            [posh.lib.datom-matcher :as dm]
+            [clojure.walk]))
 
 (defn reverse-lookup? [attr]
   (= (first (name attr)) '\_))

--- a/src/posh/lib/q_analyze.cljc
+++ b/src/posh/lib/q_analyze.cljc
@@ -3,6 +3,7 @@
    [posh.lib.util :as util]
    [posh.lib.datom-matcher :as dm]
    [posh.lib.pull-analyze :as pa]
+   [clojure.walk]
    #?(:clj [clojure.core.match :refer [match]]
       :cljs [cljs.core.match :refer-macros [match]])))
 

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -12,7 +12,7 @@
 (defn safe-pull
   [dcfg db query id]
   (cond
-    (integer? id)
+    (number? id)
     ((:pull* dcfg) db query id)
     (vector? id)
     (if-let [eid ((:entid dcfg) db id)]


### PR DESCRIPTION
Changed the id check in safe-pull to check for number? instead of integer? so it can be used with ids like `5.036617769192117e+47`