### PR TITLE
Added support for tuples values on query :in or :where

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .hg/
 figwheel_server.log
 /resources/public/js
+/out/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ even after the component using that query is un-rendered. (Thanks, [metasoarous]
   they sort-of worked in the older version. If you need to use those,
   just keep using the older version until those expressions are
   supported.
-  
+
 ## Overview
 
 Posh gives you two functions to retrieve data from the database from
@@ -307,7 +307,7 @@ one day explain further.
 ### Editable Label
 
 This component will show the text value
-for any entity and attrib combo. There is an "edit" button that, when clicked, 
+for any entity and attrib combo. There is an "edit" button that, when clicked,
 creates an `:edit` entity that keeps track of the
 temporary text typed in the edit box. The "done" button resets the original
 value of the entity and attrib and deletes the `:edit` entity. The
@@ -368,6 +368,20 @@ eventually will do this, though currently it just copies the entire
 Datomic db over to DataScript.
 
 See our Gitter room for updates: https://gitter.im/mpdairy/posh
+
+## Developing this library
+
+Start a Clojure REPL via your normal way -- `M-x cider-jack-in` for Emacs users.
+
+Start a CLJS REPL via `lein trampoline cljsbuild repl-listen`
+
+Run tests with `lein test`
+
+Files of interest:
+
+* posh.clj.datomic.clj - Clojure Datomic API
+* posh.clj.datascript.clj - Clojure Datascript API
+* posh.reagent - CLJS Datascript API
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -375,13 +375,15 @@ Start a Clojure REPL via your normal way -- `M-x cider-jack-in` for Emacs users.
 
 Start a CLJS REPL via `lein trampoline cljsbuild repl-listen`
 
-Run tests with `lein test`
-
 Files of interest:
 
 * posh.clj.datomic.clj - Clojure Datomic API
 * posh.clj.datascript.clj - Clojure Datascript API
 * posh.reagent - CLJS Datascript API
+
+### Running tests
+
+Run `lein test` from project root
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,13 @@
-(defproject posh "0.5.6"
+(defproject posh "0.5.7-SNAPSHOT"
   :description "Luxuriously easy and powerful Reagent / Datascript front-end framework"
   :url "http://github.com/mpdairy/posh/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.228"]
-                 #_[datascript "0.15.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/clojurescript "1.10.520"]
+                 ;; prev version library was using
+                 ;;[org.clojure/clojurescript "1.7.228"]
+                 [datascript "0.18.6"]
                  #_[com.datomic/datomic-free "0.9.5407"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
   :plugins [[lein-cljsbuild "1.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -5,20 +5,17 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.520"]
-                 ;; prev version library was using
-                 ;;[org.clojure/clojurescript "1.7.228"]
-                 [datascript "0.18.6"]
+                 #_[datascript "0.18.6"]
                  #_[com.datomic/datomic-free "0.9.5407"]
-                 [org.clojure/core.match "0.3.0-alpha4"]]
+                 [org.clojure/core.match "0.3.0"]]
   :plugins [[lein-cljsbuild "1.1.3"]]
-  :cljsbuild {
-              :builds [ {:id "posh"
+  :profiles {:test {:dependencies [[datascript "0.18.6"]]}}
+  :cljsbuild {:builds [ {:id "posh"
                          :source-paths ["src/"]
                          :figwheel false
                          :compiler {:main "posh.core"
                                     :asset-path "js"
                                     :output-to "resources/public/js/main.js"
-                                    :output-dir "resources/public/js"} } ]
-              }
+                                    :output-dir "resources/public/js"} } ]}
   :scm {:name "git"
         :url "https://github.com/mpdairy/posh"})

--- a/src/posh/clj/datascript.clj
+++ b/src/posh/clj/datascript.clj
@@ -17,8 +17,4 @@
               :make-reaction rx/make-reaction}]
     (assoc dcfg :pull (partial base/safe-pull dcfg))))
 
-(def instrument-q
-  "Exists only so CIDER can instrument plugin-base/q for debugging"
-  (partial #'base/q dcfg))
-
 (base/add-plugin dcfg)

--- a/src/posh/clj/datascript.clj
+++ b/src/posh/clj/datascript.clj
@@ -15,6 +15,10 @@
               :conn?         d/conn?
               :ratom         rx/atom
               :make-reaction rx/make-reaction}]
-   (assoc dcfg :pull (partial base/safe-pull dcfg))))
+    (assoc dcfg :pull (partial base/safe-pull dcfg))))
+
+(def instrument-q
+  "Exists only so CIDER can instrument plugin-base/q for debugging"
+  (partial #'base/q dcfg))
 
 (base/add-plugin dcfg)

--- a/src/posh/reagent.cljs
+++ b/src/posh/reagent.cljs
@@ -1,7 +1,7 @@
 (ns posh.reagent
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [posh.plugin-base :as base
-              :include-macros]
+             :include-macros true]
             [datascript.core :as d]
             [reagent.core :as r]
             [reagent.ratom :as ra]))

--- a/test/posh/lib/datascript_test.cljc
+++ b/test/posh/lib/datascript_test.cljc
@@ -1,0 +1,106 @@
+(ns posh.lib.datascript-test
+  "Created to assist development of 'tuple value' feature
+  see https://github.com/mpdairy/posh/issues/37"
+  (:require [clojure.test :refer [is deftest testing]]
+            [datascript.core :as dt]
+            [posh.clj.datascript :as d]))
+
+(deftest test-datascript-conn
+  (testing "Basic Datascipt dependency exists"
+    (let [conn (dt/create-conn)]
+      (is (some? conn) "Datascript connection can be created"))))
+
+(deftest test-simple-query
+  (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
+        _ (d/posh! conn)
+        tran-a (d/transact! conn [{:a "foo"}])
+        eid (->> (d/q '[:find ?e
+                        :where [?e :a "foo"]] conn)
+                 deref
+                 ffirst)]
+    (is (some? eid) "Entity should be returned from basic matching query")))
+
+;; NOTE: Hardcoding in a lookup-ref in :where isn't supposed to work -- only testing :in here
+;;       https://docs.datomic.com/on-prem/identity.html#lookup-refs
+(deftest test-lookup-ref-in
+  (testing "Lookups refs work within query :in"
+    (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
+          _ (d/posh! conn)
+          tran-a (d/transact! conn [{:a "foo"
+                                     :b "bar"
+                                     :c "baz"}])
+          b (->> (d/q '[:find ?b ?c
+                        :in $ ?lookup
+                        :where
+                        [?lookup :b ?b]
+                        [?lookup :c ?c]]
+                      conn [:a "foo"])
+                 deref
+                 first)]
+      (is (= b ["bar" "baz"])))))
+
+(deftest test-lookup-ref-transact
+  (testing "Lookups refs work via db/transact"
+    (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
+          _ (d/posh! conn)
+          tran-a (d/transact! conn [{:a "foo"
+                                     :b "bar"}])
+          ent-a (->> (d/q '[:find ?e
+                            :where [?e :a "foo"]] conn)
+                     deref
+                     ffirst
+                     (dt/entity (dt/db conn))
+                     dt/touch)
+          tran-b (d/transact! conn [[:db/add [:a "foo"] :b "zim"]])
+          ent-b (->> (d/q '[:find ?e
+                            :where [?e :a "foo"]] conn)
+                     deref
+                     ffirst
+                     (dt/entity (dt/db conn))
+                     dt/touch)]
+      (is (= (:b ent-a) "bar"))
+      (is (= (:b ent-b) "zim") "lookup ref overwrote previous value")
+      (is (= (:db/id ent-a) (:db/id ent-b)) "lookup ref modified same entity as original tx"))))
+
+(deftest test-tuple-value-in
+  (testing "Query for tuple values works via :in"
+    (let [conn (dt/create-conn)
+          _ (d/posh! conn)
+          tran (d/transact! conn [{:a ["foo" "bar"]
+                                   :b 42}])
+          ent (->> (d/q '[:find ?e
+                          :in $ ?v
+                          :where [?e :a ?v]] conn ["foo" "bar"])
+                   deref
+                   ffirst
+                   (dt/entity (dt/db conn))
+                   dt/touch)]
+      (= ["foo" "bar"] (:a ent))
+      (= 42 (:b ent)))))
+
+(deftest test-tuple-value-where
+  (testing "Query for tuple values works in :where clause"
+    (let [conn (dt/create-conn)
+          _ (d/posh! conn)
+          tran (d/transact! conn [{:a ["foo" "bar"]
+                                   :b 42}])
+          ent (->> (d/q '[:find ?e
+                          :where [?e :a ["foo" "bar"]]] conn)
+                   deref
+                   ffirst
+                   (dt/entity (dt/db conn))
+                   dt/touch)]
+      (= ["foo" "bar"] (:a ent))
+      (= 42 (:b ent)))))
+
+(defn test-all
+  []
+  (let [names ["test-lookup-ref-in"
+               "test-lookup-ref-transact"
+               "test-tuple-value-in"
+               "test-tuple-value-where"]]
+    (for [name names]
+      (do (println "Starting" name "...")
+          (Thread/sleep 3000)
+          ((ns-resolve *ns* (symbol name)))
+          (Thread/sleep 25)))))


### PR DESCRIPTION
+ Updated q-analyze/resolve-any-idents to ID lookup-refs :in query. Assumed that lookup-refs are either eid in :where clause, or if in value place, that schema has :db/valueType :db.type/ref
+ Simple tests on lookup refs & tuple queries in datascript_test.cljc
+ Updated dependencies in project.clj

My understanding of the rules for differentiating lookup-refs:
```
;; ---- :where ----
;; All vectors in :where clause are values because lookup-refs are not allowed in them

;; ---- :in ----
;; Must look at query & understand how variable is being used in :where tuple
;; If variable used as 1st element (entity), always must be lookup-ref
;; If variable used as 3rd element (value), check attribute in schema for :db.valueType :db.type/ref
;; EX: :where [?e :foo ?v]
         :in ?v    = [:x 10]
;; -- check schema for :db/type of :foo, if not db.type/ref then it's a vector value
```

Fixes #37 , re-posh https://github.com/denistakeda/re-posh/issues/32

This also includes #31, which I rediscovered & fixed in the course of this PR.