### PR TITLE
Pull-many support + vectors as query values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .hg/
 figwheel_server.log
 /resources/public/js
+/out/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ even after the component using that query is un-rendered. (Thanks, [metasoarous]
   they sort-of worked in the older version. If you need to use those,
   just keep using the older version until those expressions are
   supported.
-  
+
 ## Overview
 
 Posh gives you two functions to retrieve data from the database from
@@ -307,7 +307,7 @@ one day explain further.
 ### Editable Label
 
 This component will show the text value
-for any entity and attrib combo. There is an "edit" button that, when clicked, 
+for any entity and attrib combo. There is an "edit" button that, when clicked,
 creates an `:edit` entity that keeps track of the
 temporary text typed in the edit box. The "done" button resets the original
 value of the entity and attrib and deletes the `:edit` entity. The
@@ -368,6 +368,20 @@ eventually will do this, though currently it just copies the entire
 Datomic db over to DataScript.
 
 See our Gitter room for updates: https://gitter.im/mpdairy/posh
+
+## Developing this library
+
+Start a Clojure REPL via your normal way -- `M-x cider-jack-in` for Emacs users.
+
+Start a CLJS REPL via `lein trampoline cljsbuild repl-listen`
+
+Run tests with `lein test`
+
+Files of interest:
+
+* posh.clj.datomic.clj - Clojure Datomic API
+* posh.clj.datascript.clj - Clojure Datascript API
+* posh.reagent - CLJS Datascript API
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -375,13 +375,15 @@ Start a Clojure REPL via your normal way -- `M-x cider-jack-in` for Emacs users.
 
 Start a CLJS REPL via `lein trampoline cljsbuild repl-listen`
 
-Run tests with `lein test`
-
 Files of interest:
 
 * posh.clj.datomic.clj - Clojure Datomic API
 * posh.clj.datascript.clj - Clojure Datascript API
 * posh.reagent - CLJS Datascript API
+
+### Running tests
+
+Run `lein test` from project root
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,13 @@
-(defproject posh "0.5.6"
+(defproject posh "0.5.7-SNAPSHOT"
   :description "Luxuriously easy and powerful Reagent / Datascript front-end framework"
   :url "http://github.com/mpdairy/posh/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.228"]
-                 #_[datascript "0.15.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/clojurescript "1.10.520"]
+                 ;; prev version library was using
+                 ;;[org.clojure/clojurescript "1.7.228"]
+                 [datascript "0.18.6"]
                  #_[com.datomic/datomic-free "0.9.5407"]
                  [org.clojure/core.match "0.3.0-alpha4"]]
   :plugins [[lein-cljsbuild "1.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject posh "0.5.7-SNAPSHOT"
+(defproject posh "0.5.8-SNAPSHOT"
   :description "Luxuriously easy and powerful Reagent / Datascript front-end framework"
   :url "http://github.com/mpdairy/posh/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.520"]
-                 #_[datascript "0.18.6"]
+                 [datascript "0.18.6"]
                  #_[com.datomic/datomic-free "0.9.5407"]
                  [org.clojure/core.match "0.3.0"]]
   :plugins [[lein-cljsbuild "1.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.questyarbrough/posh "0.5.8-SNAPSHOT"
+(defproject posh "0.5.7"
   :description "Luxuriously easy and powerful Reagent / Datascript front-end framework"
   :url "http://github.com/mpdairy/posh/"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject posh "0.5.8-SNAPSHOT"
+(defproject org.clojars.questyarbrough/posh "0.5.8-SNAPSHOT"
   :description "Luxuriously easy and powerful Reagent / Datascript front-end framework"
   :url "http://github.com/mpdairy/posh/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.520"]
-                 [datascript "0.18.6"]
+                 #_[datascript "0.18.6"]
                  #_[com.datomic/datomic-free "0.9.5407"]
                  [org.clojure/core.match "0.3.0"]]
   :plugins [[lein-cljsbuild "1.1.3"]]

--- a/project.clj
+++ b/project.clj
@@ -5,20 +5,17 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.520"]
-                 ;; prev version library was using
-                 ;;[org.clojure/clojurescript "1.7.228"]
-                 [datascript "0.18.6"]
+                 #_[datascript "0.18.6"]
                  #_[com.datomic/datomic-free "0.9.5407"]
-                 [org.clojure/core.match "0.3.0-alpha4"]]
+                 [org.clojure/core.match "0.3.0"]]
   :plugins [[lein-cljsbuild "1.1.3"]]
-  :cljsbuild {
-              :builds [ {:id "posh"
+  :profiles {:test {:dependencies [[datascript "0.18.6"]]}}
+  :cljsbuild {:builds [ {:id "posh"
                          :source-paths ["src/"]
                          :figwheel false
                          :compiler {:main "posh.core"
                                     :asset-path "js"
                                     :output-to "resources/public/js/main.js"
-                                    :output-dir "resources/public/js"} } ]
-              }
+                                    :output-dir "resources/public/js"} } ]}
   :scm {:name "git"
         :url "https://github.com/mpdairy/posh"})

--- a/src/posh/clj/datascript.clj
+++ b/src/posh/clj/datascript.clj
@@ -17,8 +17,4 @@
               :make-reaction rx/make-reaction}]
     (assoc dcfg :pull (partial base/safe-pull dcfg))))
 
-(def instrument-q
-  "Exists only so CIDER can instrument plugin-base/q for debugging"
-  (partial #'base/q dcfg))
-
 (base/add-plugin dcfg)

--- a/src/posh/clj/datascript.clj
+++ b/src/posh/clj/datascript.clj
@@ -6,6 +6,7 @@
 (def dcfg
   (let [dcfg {:db            d/db
               :pull*         d/pull
+              :pull-many     d/pull-many
               :q             d/q
               :filter        d/filter
               :with          d/with

--- a/src/posh/clj/datascript.clj
+++ b/src/posh/clj/datascript.clj
@@ -15,6 +15,10 @@
               :conn?         d/conn?
               :ratom         rx/atom
               :make-reaction rx/make-reaction}]
-   (assoc dcfg :pull (partial base/safe-pull dcfg))))
+    (assoc dcfg :pull (partial base/safe-pull dcfg))))
+
+(def instrument-q
+  "Exists only so CIDER can instrument plugin-base/q for debugging"
+  (partial #'base/q dcfg))
 
 (base/add-plugin dcfg)

--- a/src/posh/clj/datomic.clj
+++ b/src/posh/clj/datomic.clj
@@ -20,6 +20,7 @@
 (def dcfg
   (let [dcfg {:db            d/db
               :pull*         d/pull
+              :pull-many     d/pull-many
               :q             d/q
               :filter        d/filter
               :with          d/with
@@ -29,6 +30,6 @@
               :conn?         conn?
               :ratom         rx/atom
               :make-reaction rx/make-reaction}]
-   (assoc dcfg :pull (partial base/safe-pull dcfg))))
+    (assoc dcfg :pull (partial base/safe-pull dcfg))))
 
 (base/add-plugin dcfg)

--- a/src/posh/lib/pull_analyze.cljc
+++ b/src/posh/lib/pull_analyze.cljc
@@ -184,14 +184,14 @@
               {:patterns
                {db-id
                 (dm/reduce-patterns
-                  (concat
-                    (when (vector? ent-id)
-                      [['_ (first ent-id) (second ent-id)]])
-                    (tx-pattern-for-pull
-                     schema
-                     prepped-pull-pattern
-                     affected-datoms
-                     false)))}})
+                 (concat
+                  (when (vector? ent-id)
+                    [['_ (first ent-id) (second ent-id)]])
+                  (tx-pattern-for-pull
+                   schema
+                   prepped-pull-pattern
+                   affected-datoms
+                   false)))}})
             (when (some #{:ref-patterns} retrieve)
               {:ref-patterns
                {db-id
@@ -201,19 +201,17 @@
                   prepped-pull-pattern
                   affected-datoms
                   true))}}))))))))
- 
+
 (defn pull-many-analyze [dcfg retrieve {:keys [db schema db-id]} pull-pattern ent-ids]
   (when-not (empty? retrieve)
     (let [resolved-ent-ids (map #((:entid dcfg) db %) ent-ids)
-          affected-datoms
-          (map (fn [ent-id] (pull-affected-datoms (:pull dcfg) db pull-pattern ent-id))
-               resolved-ent-ids)]
+          affected-datoms (pull-affected-datoms (:pull-many dcfg) db pull-pattern ent-ids)]
       (merge
        (when (some #{:results} retrieve)
          {:results affected-datoms})
        (when (some #{:datoms :datoms-t} retrieve)
          (let [datoms (mapcat #(generate-affected-tx-datoms-for-pull schema %)
-                           affected-datoms)]
+                              affected-datoms)]
            (merge
             (when (some #{:datoms} retrieve)
               {:datoms {db-id datoms}})
@@ -233,5 +231,3 @@
               (vec (cons (set resolved-ent-ids) (rest (ffirst patterns))))
               (mapcat rest patterns))
              (dm/reduce-patterns (apply concat patterns)))}})))))
-
-

--- a/src/posh/lib/update.cljc
+++ b/src/posh/lib/update.cljc
@@ -34,6 +34,20 @@
                :reload-fn posh.lib.update/update-filter-pull})
        :patterns :ref-patterns))))
 
+(defn update-pull-many [{:keys [dcfg retrieve] :as posh-tree} storage-key]
+  ;;(println "updated pull-many: " storage-key)
+  (let [[_ poshdb pull-pattern eids] storage-key]
+    (let [analysis (pa/pull-many-analyze dcfg
+                                         (cons :patterns retrieve)
+                                         (db/poshdb->analyze-db posh-tree poshdb)
+                                         pull-pattern
+                                         eids)]
+      (dissoc
+       (merge analysis
+              {:reload-patterns (:patterns analysis)
+               :reload-fn posh.lib.update/update-pull-many})
+       :patterns))))
+
 (declare update-q)
 
 (defn update-q-with-dbvarmap [{:keys [dcfg retrieve] :as posh-tree} storage-key]
@@ -86,4 +100,3 @@
     :pull (update-pull posh-tree storage-key)
     :q    (:analysis (update-q posh-tree storage-key))
     :filter-pull (update-filter-pull posh-tree storage-key)))
-

--- a/src/posh/plugin_base.cljc
+++ b/src/posh/plugin_base.cljc
@@ -92,31 +92,31 @@
    (if-let [r (get-in @posh-atom [:reactions storage-key])]
      r
      (->
-       (swap!
-         posh-atom
-         (fn [posh-atom-val]
-           (let [posh-atom-with-query (add-query-fn posh-atom-val)
-                 query-result         (:results (get (:cache posh-atom-with-query) storage-key))
-                 query-ratom          (or (get (:ratoms posh-atom-with-query) storage-key)
-                                          ((:ratom dcfg) query-result))
-                 query-reaction       ((:make-reaction dcfg)
-                                        (fn []
-                                          ;;(println "RENDERING: " storage-key)
-                                          @query-ratom)
-                                        :on-dispose
-                                        (fn [_ _]
-                                          ;;(println "no DISPOSING: " storage-key)
-                                          (when-not (= (:cache options) :forever)
-                                            (swap! posh-atom
-                                                   (fn [posh-atom-val]
-                                                     (assoc (p/remove-item posh-atom-val storage-key)
-                                                       :ratoms (dissoc (:ratoms posh-atom-val) storage-key)
-                                                       :reactions (dissoc (:reactions posh-atom-val) storage-key)))))))]
-             (assoc posh-atom-with-query
-               :ratoms (assoc (:ratoms posh-atom-with-query) storage-key query-ratom)
-               :reactions (assoc (:reactions posh-atom-with-query) storage-key query-reaction)))))
-       :reactions
-       (get storage-key))))
+      (swap!
+       posh-atom
+       (fn [posh-atom-val]
+         (let [posh-atom-with-query (add-query-fn posh-atom-val)
+               query-result         (:results (get (:cache posh-atom-with-query) storage-key))
+               query-ratom          (or (get (:ratoms posh-atom-with-query) storage-key)
+                                        ((:ratom dcfg) query-result))
+               query-reaction       ((:make-reaction dcfg)
+                                     (fn []
+                                       ;;(println "RENDERING: " storage-key)
+                                       @query-ratom)
+                                     :on-dispose
+                                     (fn [_ _]
+                                       ;;(println "no DISPOSING: " storage-key)
+                                       (when-not (= (:cache options) :forever)
+                                         (swap! posh-atom
+                                                (fn [posh-atom-val]
+                                                  (assoc (p/remove-item posh-atom-val storage-key)
+                                                         :ratoms (dissoc (:ratoms posh-atom-val) storage-key)
+                                                         :reactions (dissoc (:reactions posh-atom-val) storage-key)))))))]
+           (assoc posh-atom-with-query
+                  :ratoms (assoc (:ratoms posh-atom-with-query) storage-key query-ratom)
+                  :reactions (assoc (:reactions posh-atom-with-query) storage-key query-reaction)))))
+      :reactions
+      (get storage-key))))
   ([dcfg posh-atom storage-key add-query-fn]
    (make-query-reaction dcfg posh-atom storage-key add-query-fn {})))
 
@@ -142,6 +142,19 @@
     (dissoc
      (u/update-pull @posh-atom storage-key)
      :reload-fn)))
+
+(defn pull-many
+  ([dcfg poshdb pull-pattern eids options]
+   (let [true-poshdb (get-db dcfg poshdb)
+         storage-key [:pull-many true-poshdb pull-pattern eids]
+         posh-atom   (get-posh-atom dcfg poshdb)]
+     (make-query-reaction dcfg
+                          posh-atom
+                          storage-key
+                          #(p/add-pull-many % true-poshdb pull-pattern eids)
+                          options)))
+  ([dcfg poshdb pull-pattern eids]
+   (pull-many dcfg poshdb pull-pattern eids {})))
 
 (defn pull-tx [dcfg tx-patterns poshdb pull-pattern eid]
   (println "pull-tx is deprecated. Calling pull without your tx-patterns.")
@@ -242,6 +255,7 @@
        (def ~'pull                (partial posh.plugin-base/pull                ~dcfg))
        (def ~'pull-info           (partial posh.plugin-base/pull-info           ~dcfg))
        (def ~'pull-tx             (partial posh.plugin-base/pull-tx             ~dcfg))
+       (def ~'pull-many           (partial posh.plugin-base/pull-many           ~dcfg))
        (def ~'parse-q-query       (partial posh.plugin-base/parse-q-query       ~dcfg))
        (def ~'q-args-count        (partial posh.plugin-base/q-args-count        ~dcfg))
        (def ~'q                   (partial posh.plugin-base/q                   ~dcfg))

--- a/src/posh/reagent.cljs
+++ b/src/posh/reagent.cljs
@@ -9,6 +9,7 @@
 (def dcfg
   (let [dcfg {:db            d/db
               :pull*         d/pull
+              :pull-many     d/pull-many
               :q             d/q
               :filter        d/filter
               :with          d/with
@@ -18,6 +19,6 @@
               :conn?         d/conn?
               :ratom         r/atom
               :make-reaction ra/make-reaction}]
-   (assoc dcfg :pull (partial base/safe-pull dcfg))))
+    (assoc dcfg :pull (partial base/safe-pull dcfg))))
 
 (base/add-plugin dcfg)

--- a/src/posh/reagent.cljs
+++ b/src/posh/reagent.cljs
@@ -1,7 +1,7 @@
 (ns posh.reagent
   (:require-macros [reagent.ratom :refer [reaction]])
   (:require [posh.plugin-base :as base
-              :include-macros]
+             :include-macros true]
             [datascript.core :as d]
             [reagent.core :as r]
             [reagent.ratom :as ra]))

--- a/test/posh/lib/datascript_test.cljc
+++ b/test/posh/lib/datascript_test.cljc
@@ -1,0 +1,106 @@
+(ns posh.lib.datascript-test
+  "Created to assist development of 'tuple value' feature
+  see https://github.com/mpdairy/posh/issues/37"
+  (:require [clojure.test :refer [is deftest testing]]
+            [datascript.core :as dt]
+            [posh.clj.datascript :as d]))
+
+(deftest test-datascript-conn
+  (testing "Basic Datascipt dependency exists"
+    (let [conn (dt/create-conn)]
+      (is (some? conn) "Datascript connection can be created"))))
+
+(deftest test-simple-query
+  (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
+        _ (d/posh! conn)
+        tran-a (d/transact! conn [{:a "foo"}])
+        eid (->> (d/q '[:find ?e
+                        :where [?e :a "foo"]] conn)
+                 deref
+                 ffirst)]
+    (is (some? eid) "Entity should be returned from basic matching query")))
+
+;; NOTE: Hardcoding in a lookup-ref in :where isn't supposed to work -- only testing :in here
+;;       https://docs.datomic.com/on-prem/identity.html#lookup-refs
+(deftest test-lookup-ref-in
+  (testing "Lookups refs work within query :in"
+    (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
+          _ (d/posh! conn)
+          tran-a (d/transact! conn [{:a "foo"
+                                     :b "bar"
+                                     :c "baz"}])
+          b (->> (d/q '[:find ?b ?c
+                        :in $ ?lookup
+                        :where
+                        [?lookup :b ?b]
+                        [?lookup :c ?c]]
+                      conn [:a "foo"])
+                 deref
+                 first)]
+      (is (= b ["bar" "baz"])))))
+
+(deftest test-lookup-ref-transact
+  (testing "Lookups refs work via db/transact"
+    (let [conn (dt/create-conn {:a {:db/unique :db.unique/identity}})
+          _ (d/posh! conn)
+          tran-a (d/transact! conn [{:a "foo"
+                                     :b "bar"}])
+          ent-a (->> (d/q '[:find ?e
+                            :where [?e :a "foo"]] conn)
+                     deref
+                     ffirst
+                     (dt/entity (dt/db conn))
+                     dt/touch)
+          tran-b (d/transact! conn [[:db/add [:a "foo"] :b "zim"]])
+          ent-b (->> (d/q '[:find ?e
+                            :where [?e :a "foo"]] conn)
+                     deref
+                     ffirst
+                     (dt/entity (dt/db conn))
+                     dt/touch)]
+      (is (= (:b ent-a) "bar"))
+      (is (= (:b ent-b) "zim") "lookup ref overwrote previous value")
+      (is (= (:db/id ent-a) (:db/id ent-b)) "lookup ref modified same entity as original tx"))))
+
+(deftest test-tuple-value-in
+  (testing "Query for tuple values works via :in"
+    (let [conn (dt/create-conn)
+          _ (d/posh! conn)
+          tran (d/transact! conn [{:a ["foo" "bar"]
+                                   :b 42}])
+          ent (->> (d/q '[:find ?e
+                          :in $ ?v
+                          :where [?e :a ?v]] conn ["foo" "bar"])
+                   deref
+                   ffirst
+                   (dt/entity (dt/db conn))
+                   dt/touch)]
+      (= ["foo" "bar"] (:a ent))
+      (= 42 (:b ent)))))
+
+(deftest test-tuple-value-where
+  (testing "Query for tuple values works in :where clause"
+    (let [conn (dt/create-conn)
+          _ (d/posh! conn)
+          tran (d/transact! conn [{:a ["foo" "bar"]
+                                   :b 42}])
+          ent (->> (d/q '[:find ?e
+                          :where [?e :a ["foo" "bar"]]] conn)
+                   deref
+                   ffirst
+                   (dt/entity (dt/db conn))
+                   dt/touch)]
+      (= ["foo" "bar"] (:a ent))
+      (= 42 (:b ent)))))
+
+(defn test-all
+  []
+  (let [names ["test-lookup-ref-in"
+               "test-lookup-ref-transact"
+               "test-tuple-value-in"
+               "test-tuple-value-where"]]
+    (for [name names]
+      (do (println "Starting" name "...")
+          (Thread/sleep 3000)
+          ((ns-resolve *ns* (symbol name)))
+          (Thread/sleep 25)))))

--- a/test/posh/lib/datascript_test.cljc
+++ b/test/posh/lib/datascript_test.cljc
@@ -136,7 +136,7 @@
           ;;dtlg-raw (dt/pull-many (dt/db conn) '[*] eids)
           entity-reaction (d/pull-many conn '[*] eids)]
       (is (= ents (map #(select-keys % [:a :b]) @entity-reaction))
-          "Entities in reaction should match input entities")
+          "Entities in reaction should match input entities against input sequence of eids")
       (let [updated-ents (vec (map #(update % :b inc) @entity-reaction))]
         (d/transact! conn updated-ents)
         (is (= updated-ents @entity-reaction)


### PR DESCRIPTION
Adds support for `pull-many` in the Posh API. Includes a basic test included below to demonstrate usage.

```clj
(let [conn (dt/create-conn)
      _ (d/posh! conn)
      ents [{:a "foo" :b 42}
            {:a "bar" :b 52}
            {:a "baz" :b 62}]
      tran (d/transact! conn ents)
      eids (->> (d/q '[:find ?e
                       :where [?e :a _]] conn)
                deref
                (reduce into [])
                reverse)
      ;;dtlg-raw (dt/pull-many (dt/db conn) '[*] eids)
      entity-reaction (d/pull-many conn '[*] eids)]
  (is (= ents (map #(select-keys % [:a :b]) @entity-reaction))
      "Entities in reaction should match input entities against input sequence of eids")
  (let [updated-ents (vec (map #(update % :b inc) @entity-reaction))]
    (d/transact! conn updated-ents)
    (is (= updated-ents @entity-reaction)
        "Entities in reaction should updated after transact")))
```

I noticed that `pull-many-analyze` already existed, so my only change there was using Datomic's official `pull-many` function. I added similar functions to the existing `pull` in other namespaces & it "just worked", but there could certainly be problems with this implementation. Eyes are appreciated.

This PR also includes the "vector as value" support & tests from PR #38 (which I've closed), but I can split these PRs back out if desired.

Fixes #37 , re-posh denistakeda/re-posh#32

Supports solution for denistakeda/re-posh#26